### PR TITLE
Revert "Using '__IOM' for peripheral register definitions"

### DIFF
--- a/Include/stm32f401xc.h
+++ b/Include/stm32f401xc.h
@@ -151,33 +151,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -187,11 +187,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -200,10 +200,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -213,20 +213,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -235,12 +235,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -249,13 +249,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -264,15 +264,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -281,11 +281,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -294,16 +294,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /** 
@@ -312,10 +312,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -325,8 +325,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -335,38 +335,38 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
   uint32_t      RESERVED7[1];  /*!< Reserved, 0x88                                                                    */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
 } RCC_TypeDef;
 
 /** 
@@ -375,46 +375,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -423,26 +423,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -451,15 +451,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -469,27 +469,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -498,13 +498,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -513,33 +513,33 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 /** 
   * @brief USB_OTG_Core_Registers
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved40[48];           /*!< Reserved                                0x40-0xFF */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -547,26 +547,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -574,13 +574,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -589,12 +589,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -603,13 +603,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -617,12 +617,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f401xe.h
+++ b/Include/stm32f401xe.h
@@ -151,33 +151,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -187,11 +187,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -200,10 +200,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -213,20 +213,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -235,12 +235,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -249,13 +249,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -264,15 +264,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -281,11 +281,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -294,16 +294,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /** 
@@ -312,10 +312,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -325,8 +325,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -335,38 +335,38 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
   uint32_t      RESERVED7[1];  /*!< Reserved, 0x88                                                                    */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
 } RCC_TypeDef;
 
 /** 
@@ -375,46 +375,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -423,26 +423,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -451,15 +451,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -469,27 +469,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -498,13 +498,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -513,33 +513,33 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 /** 
   * @brief USB_OTG_Core_Registers
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved40[48];           /*!< Reserved                                0x40-0xFF */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -547,26 +547,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -574,13 +574,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -589,12 +589,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -603,13 +603,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -617,12 +617,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f405xx.h
+++ b/Include/stm32f405xx.h
@@ -175,33 +175,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -212,10 +212,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -224,10 +224,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -236,8 +236,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -246,26 +246,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -276,11 +276,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -289,20 +289,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -311,10 +311,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -324,20 +324,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -346,12 +346,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -360,13 +360,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 
@@ -377,7 +377,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
 } FSMC_Bank1_TypeDef;
 
 /** 
@@ -386,7 +386,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FSMC_Bank1E_TypeDef;
 
 /** 
@@ -395,20 +395,20 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
-  __IOM uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
-  __IOM uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
-  __IOM uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
+  __IO uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
+  __IO uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
+  __IO uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
+  __IO uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
   uint32_t      RESERVED0;  /*!< Reserved, 0x70                                                            */
-  __IOM uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
+  __IO uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
   uint32_t      RESERVED1;  /*!< Reserved, 0x78                                                            */
   uint32_t      RESERVED2;  /*!< Reserved, 0x7C                                                            */
-  __IOM uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
-  __IOM uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
-  __IOM uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
-  __IOM uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
+  __IO uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
+  __IO uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
+  __IO uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
+  __IO uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
   uint32_t      RESERVED3;  /*!< Reserved, 0x90                                                            */
-  __IOM uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
+  __IO uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
 } FSMC_Bank2_3_TypeDef;
 
 /** 
@@ -417,11 +417,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
-  __IOM uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
-  __IOM uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
-  __IOM uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
-  __IOM uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
+  __IO uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
+  __IO uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
+  __IO uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
+  __IO uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
+  __IO uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
 } FSMC_Bank4_TypeDef; 
 
 /** 
@@ -430,15 +430,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -447,11 +447,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -460,15 +460,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
 } I2C_TypeDef;
 
 /** 
@@ -477,10 +477,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -490,8 +490,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -500,36 +500,36 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
 } RCC_TypeDef;
 
 /** 
@@ -538,46 +538,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -586,26 +586,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -614,15 +614,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -632,27 +632,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -661,13 +661,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -676,9 +676,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -687,9 +687,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -697,24 +697,24 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved40[48];           /*!< Reserved                                0x40-0xFF */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -722,26 +722,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -749,13 +749,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -764,12 +764,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -778,13 +778,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -792,12 +792,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f407xx.h
+++ b/Include/stm32f407xx.h
@@ -178,33 +178,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -215,10 +215,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -227,10 +227,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -239,8 +239,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -249,26 +249,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -279,11 +279,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -292,20 +292,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -314,10 +314,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 /** 
@@ -326,17 +326,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
-  __IOM uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
-  __IOM uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
-  __IOM uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
-  __IOM uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
-  __IOM uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
-  __IOM uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
-  __IOM uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
-  __IOM uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
-  __IOM uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
-  __IOM uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
+  __IO uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
+  __IO uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
+  __IO uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
+  __IO uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
+  __IO uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
+  __IO uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
+  __IO uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
+  __IO uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
+  __IO uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
+  __IO uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
+  __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
 } DCMI_TypeDef;
 
 /** 
@@ -345,20 +345,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -367,73 +367,73 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MACCR;
-  __IOM uint32_t MACFFR;
-  __IOM uint32_t MACHTHR;
-  __IOM uint32_t MACHTLR;
-  __IOM uint32_t MACMIIAR;
-  __IOM uint32_t MACMIIDR;
-  __IOM uint32_t MACFCR;
-  __IOM uint32_t MACVLANTR;             /*    8 */
+  __IO uint32_t MACCR;
+  __IO uint32_t MACFFR;
+  __IO uint32_t MACHTHR;
+  __IO uint32_t MACHTLR;
+  __IO uint32_t MACMIIAR;
+  __IO uint32_t MACMIIDR;
+  __IO uint32_t MACFCR;
+  __IO uint32_t MACVLANTR;             /*    8 */
   uint32_t      RESERVED0[2];
-  __IOM uint32_t MACRWUFFR;             /*   11 */
-  __IOM uint32_t MACPMTCSR;
+  __IO uint32_t MACRWUFFR;             /*   11 */
+  __IO uint32_t MACPMTCSR;
   uint32_t      RESERVED1;
-  __IOM uint32_t MACDBGR;
-  __IOM uint32_t MACSR;                 /*   15 */
-  __IOM uint32_t MACIMR;
-  __IOM uint32_t MACA0HR;
-  __IOM uint32_t MACA0LR;
-  __IOM uint32_t MACA1HR;
-  __IOM uint32_t MACA1LR;
-  __IOM uint32_t MACA2HR;
-  __IOM uint32_t MACA2LR;
-  __IOM uint32_t MACA3HR;
-  __IOM uint32_t MACA3LR;               /*   24 */
+  __IO uint32_t MACDBGR;
+  __IO uint32_t MACSR;                 /*   15 */
+  __IO uint32_t MACIMR;
+  __IO uint32_t MACA0HR;
+  __IO uint32_t MACA0LR;
+  __IO uint32_t MACA1HR;
+  __IO uint32_t MACA1LR;
+  __IO uint32_t MACA2HR;
+  __IO uint32_t MACA2LR;
+  __IO uint32_t MACA3HR;
+  __IO uint32_t MACA3LR;               /*   24 */
   uint32_t      RESERVED2[40];
-  __IOM uint32_t MMCCR;                 /*   65 */
-  __IOM uint32_t MMCRIR;
-  __IOM uint32_t MMCTIR;
-  __IOM uint32_t MMCRIMR;
-  __IOM uint32_t MMCTIMR;               /*   69 */
+  __IO uint32_t MMCCR;                 /*   65 */
+  __IO uint32_t MMCRIR;
+  __IO uint32_t MMCTIR;
+  __IO uint32_t MMCRIMR;
+  __IO uint32_t MMCTIMR;               /*   69 */
   uint32_t      RESERVED3[14];
-  __IOM uint32_t MMCTGFSCCR;            /*   84 */
-  __IOM uint32_t MMCTGFMSCCR;
+  __IO uint32_t MMCTGFSCCR;            /*   84 */
+  __IO uint32_t MMCTGFMSCCR;
   uint32_t      RESERVED4[5];
-  __IOM uint32_t MMCTGFCR;
+  __IO uint32_t MMCTGFCR;
   uint32_t      RESERVED5[10];
-  __IOM uint32_t MMCRFCECR;
-  __IOM uint32_t MMCRFAECR;
+  __IO uint32_t MMCRFCECR;
+  __IO uint32_t MMCRFAECR;
   uint32_t      RESERVED6[10];
-  __IOM uint32_t MMCRGUFCR;
+  __IO uint32_t MMCRGUFCR;
   uint32_t      RESERVED7[334];
-  __IOM uint32_t PTPTSCR;
-  __IOM uint32_t PTPSSIR;
-  __IOM uint32_t PTPTSHR;
-  __IOM uint32_t PTPTSLR;
-  __IOM uint32_t PTPTSHUR;
-  __IOM uint32_t PTPTSLUR;
-  __IOM uint32_t PTPTSAR;
-  __IOM uint32_t PTPTTHR;
-  __IOM uint32_t PTPTTLR;
-  __IOM uint32_t RESERVED8;
-  __IOM uint32_t PTPTSSR;
+  __IO uint32_t PTPTSCR;
+  __IO uint32_t PTPSSIR;
+  __IO uint32_t PTPTSHR;
+  __IO uint32_t PTPTSLR;
+  __IO uint32_t PTPTSHUR;
+  __IO uint32_t PTPTSLUR;
+  __IO uint32_t PTPTSAR;
+  __IO uint32_t PTPTTHR;
+  __IO uint32_t PTPTTLR;
+  __IO uint32_t RESERVED8;
+  __IO uint32_t PTPTSSR;
   uint32_t      RESERVED9[565];
-  __IOM uint32_t DMABMR;
-  __IOM uint32_t DMATPDR;
-  __IOM uint32_t DMARPDR;
-  __IOM uint32_t DMARDLAR;
-  __IOM uint32_t DMATDLAR;
-  __IOM uint32_t DMASR;
-  __IOM uint32_t DMAOMR;
-  __IOM uint32_t DMAIER;
-  __IOM uint32_t DMAMFBOCR;
-  __IOM uint32_t DMARSWTR;
+  __IO uint32_t DMABMR;
+  __IO uint32_t DMATPDR;
+  __IO uint32_t DMARPDR;
+  __IO uint32_t DMARDLAR;
+  __IO uint32_t DMATDLAR;
+  __IO uint32_t DMASR;
+  __IO uint32_t DMAOMR;
+  __IO uint32_t DMAIER;
+  __IO uint32_t DMAMFBOCR;
+  __IO uint32_t DMARSWTR;
   uint32_t      RESERVED10[8];
-  __IOM uint32_t DMACHTDR;
-  __IOM uint32_t DMACHRDR;
-  __IOM uint32_t DMACHTBAR;
-  __IOM uint32_t DMACHRBAR;
+  __IO uint32_t DMACHTDR;
+  __IO uint32_t DMACHRDR;
+  __IO uint32_t DMACHTBAR;
+  __IO uint32_t DMACHRBAR;
 } ETH_TypeDef;
 
 /** 
@@ -442,12 +442,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -456,13 +456,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 
@@ -473,7 +473,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
 } FSMC_Bank1_TypeDef;
 
 /** 
@@ -482,7 +482,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FSMC_Bank1E_TypeDef;
 
 /** 
@@ -491,20 +491,20 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
-  __IOM uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
-  __IOM uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
-  __IOM uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
+  __IO uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
+  __IO uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
+  __IO uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
+  __IO uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
   uint32_t      RESERVED0;  /*!< Reserved, 0x70                                                            */
-  __IOM uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
+  __IO uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
   uint32_t      RESERVED1;  /*!< Reserved, 0x78                                                            */
   uint32_t      RESERVED2;  /*!< Reserved, 0x7C                                                            */
-  __IOM uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
-  __IOM uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
-  __IOM uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
-  __IOM uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
+  __IO uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
+  __IO uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
+  __IO uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
+  __IO uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
   uint32_t      RESERVED3;  /*!< Reserved, 0x90                                                            */
-  __IOM uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
+  __IO uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
 } FSMC_Bank2_3_TypeDef;
 
 /** 
@@ -513,11 +513,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
-  __IOM uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
-  __IOM uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
-  __IOM uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
-  __IOM uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
+  __IO uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
+  __IO uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
+  __IO uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
+  __IO uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
+  __IO uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
 } FSMC_Bank4_TypeDef; 
 
 /** 
@@ -526,15 +526,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -543,11 +543,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -556,15 +556,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
 } I2C_TypeDef;
 
 /** 
@@ -573,10 +573,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -586,8 +586,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -596,36 +596,36 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
 } RCC_TypeDef;
 
 /** 
@@ -634,46 +634,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -682,26 +682,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -710,15 +710,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -728,27 +728,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -757,13 +757,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -772,9 +772,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -783,9 +783,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -793,24 +793,24 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved40[48];           /*!< Reserved                                0x40-0xFF */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -818,26 +818,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -845,13 +845,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -860,12 +860,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -874,13 +874,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -888,12 +888,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f410cx.h
+++ b/Include/stm32f410cx.h
@@ -147,33 +147,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -183,11 +183,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -196,20 +196,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -218,10 +218,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -231,20 +231,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -253,12 +253,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -267,13 +267,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -282,15 +282,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -299,13 +299,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED;     /*!< Reserved, 0x18                                                               */
-  __IOM uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
-  __IOM uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
+  __IO uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -314,16 +314,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /**
@@ -332,17 +332,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
-  __IOM uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
-  __IOM uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
-  __IOM uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
-  __IOM uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
-  __IOM uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
-  __IOM uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
-  __IOM uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
-  __IOM uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
-  __IOM uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
+  __IO uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
 } FMPI2C_TypeDef;
 
 /** 
@@ -351,10 +351,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -364,8 +364,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -374,33 +374,33 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
   uint32_t      RESERVED0[3];  /*!< Reserved, 0x14-0x1C                                                               */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
   uint32_t      RESERVED2[3];  /*!< Reserved, 0x34-0x3C                                                               */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
   uint32_t      RESERVED4[3];  /*!< Reserved, 0x54-0x5C                                                               */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
   uint32_t      RESERVED7[2];   /*!< Reserved, 0x84-0x88                                                              */
-  __IOM uint32_t DCKCFGR;       /*!< RCC DCKCFGR configuration register,                         Address offset: 0x8C  */
-  __IOM uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
-  __IOM uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
+  __IO uint32_t DCKCFGR;       /*!< RCC DCKCFGR configuration register,                         Address offset: 0x8C  */
+  __IO uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
 } RCC_TypeDef;
 
 /** 
@@ -409,46 +409,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -457,15 +457,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -475,27 +475,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -504,13 +504,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -519,9 +519,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -530,9 +530,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 
@@ -541,15 +541,15 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
-  __IOM uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
-  __IOM uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
-  __IOM uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
-  __IOM uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
-  __IOM uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
-  __IOM uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
-  __IOM uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
-  __IOM uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
+  __IO uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
 } LPTIM_TypeDef;
 
 /**

--- a/Include/stm32f410rx.h
+++ b/Include/stm32f410rx.h
@@ -147,33 +147,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -183,11 +183,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -196,20 +196,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -218,10 +218,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -231,20 +231,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -253,12 +253,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -267,13 +267,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -282,15 +282,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -299,13 +299,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED;     /*!< Reserved, 0x18                                                               */
-  __IOM uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
-  __IOM uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
+  __IO uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -314,16 +314,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /**
@@ -332,17 +332,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
-  __IOM uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
-  __IOM uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
-  __IOM uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
-  __IOM uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
-  __IOM uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
-  __IOM uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
-  __IOM uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
-  __IOM uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
-  __IOM uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
+  __IO uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
 } FMPI2C_TypeDef;
 
 /** 
@@ -351,10 +351,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -364,8 +364,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -374,33 +374,33 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
   uint32_t      RESERVED0[3];  /*!< Reserved, 0x14-0x1C                                                               */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
   uint32_t      RESERVED2[3];  /*!< Reserved, 0x34-0x3C                                                               */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
   uint32_t      RESERVED4[3];  /*!< Reserved, 0x54-0x5C                                                               */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
   uint32_t      RESERVED7[2];   /*!< Reserved, 0x84-0x88                                                              */
-  __IOM uint32_t DCKCFGR;       /*!< RCC DCKCFGR configuration register,                         Address offset: 0x8C  */
-  __IOM uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
-  __IOM uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
+  __IO uint32_t DCKCFGR;       /*!< RCC DCKCFGR configuration register,                         Address offset: 0x8C  */
+  __IO uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
 } RCC_TypeDef;
 
 /** 
@@ -409,46 +409,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -457,15 +457,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -475,27 +475,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -504,13 +504,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -519,9 +519,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -530,9 +530,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 
@@ -541,15 +541,15 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
-  __IOM uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
-  __IOM uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
-  __IOM uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
-  __IOM uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
-  __IOM uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
-  __IOM uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
-  __IOM uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
-  __IOM uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
+  __IO uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
 } LPTIM_TypeDef;
 
 /**

--- a/Include/stm32f410tx.h
+++ b/Include/stm32f410tx.h
@@ -144,33 +144,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -180,11 +180,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -193,20 +193,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -215,10 +215,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -228,20 +228,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -250,12 +250,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -264,13 +264,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -279,15 +279,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -296,13 +296,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED;     /*!< Reserved, 0x18                                                               */
-  __IOM uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
-  __IOM uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
+  __IO uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -311,16 +311,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /**
@@ -329,17 +329,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
-  __IOM uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
-  __IOM uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
-  __IOM uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
-  __IOM uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
-  __IOM uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
-  __IOM uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
-  __IOM uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
-  __IOM uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
-  __IOM uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
+  __IO uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
 } FMPI2C_TypeDef;
 
 /** 
@@ -348,10 +348,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -361,8 +361,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -371,33 +371,33 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
   uint32_t      RESERVED0[3];  /*!< Reserved, 0x14-0x1C                                                               */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
   uint32_t      RESERVED2[3];  /*!< Reserved, 0x34-0x3C                                                               */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
   uint32_t      RESERVED4[3];  /*!< Reserved, 0x54-0x5C                                                               */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
   uint32_t      RESERVED7[2];   /*!< Reserved, 0x84-0x88                                                              */
-  __IOM uint32_t DCKCFGR;       /*!< RCC DCKCFGR configuration register,                         Address offset: 0x8C  */
-  __IOM uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
-  __IOM uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
+  __IO uint32_t DCKCFGR;       /*!< RCC DCKCFGR configuration register,                         Address offset: 0x8C  */
+  __IO uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
 } RCC_TypeDef;
 
 /** 
@@ -406,46 +406,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -454,15 +454,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -472,27 +472,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -501,13 +501,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -516,9 +516,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -527,9 +527,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 
@@ -538,15 +538,15 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
-  __IOM uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
-  __IOM uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
-  __IOM uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
-  __IOM uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
-  __IOM uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
-  __IOM uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
-  __IOM uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
-  __IOM uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
+  __IO uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
 } LPTIM_TypeDef;
 
 /**

--- a/Include/stm32f411xe.h
+++ b/Include/stm32f411xe.h
@@ -152,33 +152,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -188,11 +188,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -201,10 +201,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -214,20 +214,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -236,12 +236,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -250,13 +250,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -265,15 +265,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -282,11 +282,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -295,16 +295,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /** 
@@ -313,10 +313,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -326,8 +326,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -336,38 +336,38 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
   uint32_t      RESERVED7[1];  /*!< Reserved, 0x88                                                                    */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
 } RCC_TypeDef;
 
 /** 
@@ -376,46 +376,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -424,26 +424,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -452,15 +452,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -470,27 +470,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -499,13 +499,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -514,33 +514,33 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 /** 
   * @brief USB_OTG_Core_Registers
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved40[48];           /*!< Reserved                                0x40-0xFF */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -548,26 +548,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -575,13 +575,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -590,12 +590,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -604,13 +604,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -618,12 +618,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f412cx.h
+++ b/Include/stm32f412cx.h
@@ -172,33 +172,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -209,10 +209,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -221,10 +221,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -233,8 +233,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -243,26 +243,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -273,11 +273,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /**
@@ -285,21 +285,21 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t FLTCR1;      /*!< DFSDM control register1,                          Address offset: 0x100 */
-  __IOM uint32_t FLTCR2;      /*!< DFSDM control register2,                          Address offset: 0x104 */
-  __IOM uint32_t FLTISR;      /*!< DFSDM interrupt and status register,              Address offset: 0x108 */
-  __IOM uint32_t FLTICR;      /*!< DFSDM interrupt flag clear register,              Address offset: 0x10C */
-  __IOM uint32_t FLTJCHGR;    /*!< DFSDM injected channel group selection register,  Address offset: 0x110 */
-  __IOM uint32_t FLTFCR;      /*!< DFSDM filter control register,                    Address offset: 0x114 */
-  __IOM uint32_t FLTJDATAR;   /*!< DFSDM data register for injected group,           Address offset: 0x118 */
-  __IOM uint32_t FLTRDATAR;   /*!< DFSDM data register for regular group,            Address offset: 0x11C */
-  __IOM uint32_t FLTAWHTR;    /*!< DFSDM analog watchdog high threshold register,    Address offset: 0x120 */
-  __IOM uint32_t FLTAWLTR;    /*!< DFSDM analog watchdog low threshold register,     Address offset: 0x124 */
-  __IOM uint32_t FLTAWSR;     /*!< DFSDM analog watchdog status register             Address offset: 0x128 */
-  __IOM uint32_t FLTAWCFR;    /*!< DFSDM analog watchdog clear flag register         Address offset: 0x12C */
-  __IOM uint32_t FLTEXMAX;    /*!< DFSDM extreme detector maximum register,          Address offset: 0x130 */
-  __IOM uint32_t FLTEXMIN;    /*!< DFSDM extreme detector minimum register           Address offset: 0x134 */
-  __IOM uint32_t FLTCNVTIMR;  /*!< DFSDM conversion timer,                           Address offset: 0x138 */
+  __IO uint32_t FLTCR1;      /*!< DFSDM control register1,                          Address offset: 0x100 */
+  __IO uint32_t FLTCR2;      /*!< DFSDM control register2,                          Address offset: 0x104 */
+  __IO uint32_t FLTISR;      /*!< DFSDM interrupt and status register,              Address offset: 0x108 */
+  __IO uint32_t FLTICR;      /*!< DFSDM interrupt flag clear register,              Address offset: 0x10C */
+  __IO uint32_t FLTJCHGR;    /*!< DFSDM injected channel group selection register,  Address offset: 0x110 */
+  __IO uint32_t FLTFCR;      /*!< DFSDM filter control register,                    Address offset: 0x114 */
+  __IO uint32_t FLTJDATAR;   /*!< DFSDM data register for injected group,           Address offset: 0x118 */
+  __IO uint32_t FLTRDATAR;   /*!< DFSDM data register for regular group,            Address offset: 0x11C */
+  __IO uint32_t FLTAWHTR;    /*!< DFSDM analog watchdog high threshold register,    Address offset: 0x120 */
+  __IO uint32_t FLTAWLTR;    /*!< DFSDM analog watchdog low threshold register,     Address offset: 0x124 */
+  __IO uint32_t FLTAWSR;     /*!< DFSDM analog watchdog status register             Address offset: 0x128 */
+  __IO uint32_t FLTAWCFR;    /*!< DFSDM analog watchdog clear flag register         Address offset: 0x12C */
+  __IO uint32_t FLTEXMAX;    /*!< DFSDM extreme detector maximum register,          Address offset: 0x130 */
+  __IO uint32_t FLTEXMIN;    /*!< DFSDM extreme detector minimum register           Address offset: 0x134 */
+  __IO uint32_t FLTCNVTIMR;  /*!< DFSDM conversion timer,                           Address offset: 0x138 */
 } DFSDM_Filter_TypeDef;
 
 /**
@@ -307,12 +307,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t CHCFGR1;     /*!< DFSDM channel configuration register1,            Address offset: 0x00 */
-  __IOM uint32_t CHCFGR2;     /*!< DFSDM channel configuration register2,            Address offset: 0x04 */
-  __IOM uint32_t CHAWSCDR;    /*!< DFSDM channel analog watchdog and
+  __IO uint32_t CHCFGR1;     /*!< DFSDM channel configuration register1,            Address offset: 0x00 */
+  __IO uint32_t CHCFGR2;     /*!< DFSDM channel configuration register2,            Address offset: 0x04 */
+  __IO uint32_t CHAWSCDR;    /*!< DFSDM channel analog watchdog and
                                   short circuit detector register,                  Address offset: 0x08 */
-  __IOM uint32_t CHWDATAR;    /*!< DFSDM channel watchdog filter data register,      Address offset: 0x0C */
-  __IOM uint32_t CHDATINR;    /*!< DFSDM channel data input register,                Address offset: 0x10 */
+  __IO uint32_t CHWDATAR;    /*!< DFSDM channel watchdog filter data register,      Address offset: 0x0C */
+  __IO uint32_t CHDATINR;    /*!< DFSDM channel data input register,                Address offset: 0x10 */
 } DFSDM_Channel_TypeDef;
 
 /** 
@@ -321,10 +321,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -334,20 +334,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -356,12 +356,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -370,13 +370,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -385,15 +385,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -402,13 +402,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED;     /*!< Reserved, 0x18                                                               */
-  __IOM uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
-  __IOM uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
+  __IO uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -417,16 +417,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /**
@@ -435,17 +435,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
-  __IOM uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
-  __IOM uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
-  __IOM uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
-  __IOM uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
-  __IOM uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
-  __IOM uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
-  __IOM uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
-  __IOM uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
-  __IOM uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
+  __IO uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
 } FMPI2C_TypeDef;
 
 /** 
@@ -454,10 +454,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -467,8 +467,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -477,37 +477,37 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
   uint32_t      RESERVED0[2];  /*!< Reserved, 0x18-0x1C                                                               */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
   uint32_t      RESERVED2[2];  /*!< Reserved, 0x38-0x3C                                                               */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
   uint32_t      RESERVED4[2];  /*!< Reserved, 0x58-0x5C                                                               */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
   uint32_t      RESERVED7;     /*!< Reserved, 0x88                                                                    */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
-  __IOM uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
-  __IOM uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
 } RCC_TypeDef;
 
 /** 
@@ -516,46 +516,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -564,26 +564,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -592,15 +592,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -610,27 +610,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -639,13 +639,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -654,9 +654,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -665,9 +665,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -675,30 +675,30 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved5[3];             /*!< Reserved                                040h-048h */
-  __IOM uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
+  __IO uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
   uint32_t  Reserved6;                /*!< Reserved                                     050h */
-  __IOM uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
+  __IO uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
   uint32_t  Reserved;                 /*!< Reserved                                     058h */
-  __IOM uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
+  __IO uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
   uint32_t  Reserved43[40];           /*!< Reserved                                058h-0FFh */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -706,26 +706,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -733,13 +733,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -748,12 +748,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -762,13 +762,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -776,12 +776,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f412rx.h
+++ b/Include/stm32f412rx.h
@@ -173,33 +173,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -210,10 +210,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -222,10 +222,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -234,8 +234,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -244,26 +244,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -274,11 +274,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /**
@@ -286,21 +286,21 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t FLTCR1;      /*!< DFSDM control register1,                          Address offset: 0x100 */
-  __IOM uint32_t FLTCR2;      /*!< DFSDM control register2,                          Address offset: 0x104 */
-  __IOM uint32_t FLTISR;      /*!< DFSDM interrupt and status register,              Address offset: 0x108 */
-  __IOM uint32_t FLTICR;      /*!< DFSDM interrupt flag clear register,              Address offset: 0x10C */
-  __IOM uint32_t FLTJCHGR;    /*!< DFSDM injected channel group selection register,  Address offset: 0x110 */
-  __IOM uint32_t FLTFCR;      /*!< DFSDM filter control register,                    Address offset: 0x114 */
-  __IOM uint32_t FLTJDATAR;   /*!< DFSDM data register for injected group,           Address offset: 0x118 */
-  __IOM uint32_t FLTRDATAR;   /*!< DFSDM data register for regular group,            Address offset: 0x11C */
-  __IOM uint32_t FLTAWHTR;    /*!< DFSDM analog watchdog high threshold register,    Address offset: 0x120 */
-  __IOM uint32_t FLTAWLTR;    /*!< DFSDM analog watchdog low threshold register,     Address offset: 0x124 */
-  __IOM uint32_t FLTAWSR;     /*!< DFSDM analog watchdog status register             Address offset: 0x128 */
-  __IOM uint32_t FLTAWCFR;    /*!< DFSDM analog watchdog clear flag register         Address offset: 0x12C */
-  __IOM uint32_t FLTEXMAX;    /*!< DFSDM extreme detector maximum register,          Address offset: 0x130 */
-  __IOM uint32_t FLTEXMIN;    /*!< DFSDM extreme detector minimum register           Address offset: 0x134 */
-  __IOM uint32_t FLTCNVTIMR;  /*!< DFSDM conversion timer,                           Address offset: 0x138 */
+  __IO uint32_t FLTCR1;      /*!< DFSDM control register1,                          Address offset: 0x100 */
+  __IO uint32_t FLTCR2;      /*!< DFSDM control register2,                          Address offset: 0x104 */
+  __IO uint32_t FLTISR;      /*!< DFSDM interrupt and status register,              Address offset: 0x108 */
+  __IO uint32_t FLTICR;      /*!< DFSDM interrupt flag clear register,              Address offset: 0x10C */
+  __IO uint32_t FLTJCHGR;    /*!< DFSDM injected channel group selection register,  Address offset: 0x110 */
+  __IO uint32_t FLTFCR;      /*!< DFSDM filter control register,                    Address offset: 0x114 */
+  __IO uint32_t FLTJDATAR;   /*!< DFSDM data register for injected group,           Address offset: 0x118 */
+  __IO uint32_t FLTRDATAR;   /*!< DFSDM data register for regular group,            Address offset: 0x11C */
+  __IO uint32_t FLTAWHTR;    /*!< DFSDM analog watchdog high threshold register,    Address offset: 0x120 */
+  __IO uint32_t FLTAWLTR;    /*!< DFSDM analog watchdog low threshold register,     Address offset: 0x124 */
+  __IO uint32_t FLTAWSR;     /*!< DFSDM analog watchdog status register             Address offset: 0x128 */
+  __IO uint32_t FLTAWCFR;    /*!< DFSDM analog watchdog clear flag register         Address offset: 0x12C */
+  __IO uint32_t FLTEXMAX;    /*!< DFSDM extreme detector maximum register,          Address offset: 0x130 */
+  __IO uint32_t FLTEXMIN;    /*!< DFSDM extreme detector minimum register           Address offset: 0x134 */
+  __IO uint32_t FLTCNVTIMR;  /*!< DFSDM conversion timer,                           Address offset: 0x138 */
 } DFSDM_Filter_TypeDef;
 
 /**
@@ -308,12 +308,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t CHCFGR1;     /*!< DFSDM channel configuration register1,            Address offset: 0x00 */
-  __IOM uint32_t CHCFGR2;     /*!< DFSDM channel configuration register2,            Address offset: 0x04 */
-  __IOM uint32_t CHAWSCDR;    /*!< DFSDM channel analog watchdog and
+  __IO uint32_t CHCFGR1;     /*!< DFSDM channel configuration register1,            Address offset: 0x00 */
+  __IO uint32_t CHCFGR2;     /*!< DFSDM channel configuration register2,            Address offset: 0x04 */
+  __IO uint32_t CHAWSCDR;    /*!< DFSDM channel analog watchdog and
                                   short circuit detector register,                  Address offset: 0x08 */
-  __IOM uint32_t CHWDATAR;    /*!< DFSDM channel watchdog filter data register,      Address offset: 0x0C */
-  __IOM uint32_t CHDATINR;    /*!< DFSDM channel data input register,                Address offset: 0x10 */
+  __IO uint32_t CHWDATAR;    /*!< DFSDM channel watchdog filter data register,      Address offset: 0x0C */
+  __IO uint32_t CHDATINR;    /*!< DFSDM channel data input register,                Address offset: 0x10 */
 } DFSDM_Channel_TypeDef;
 
 /** 
@@ -322,10 +322,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -335,20 +335,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -357,12 +357,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -371,13 +371,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 
@@ -388,7 +388,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
 } FSMC_Bank1_TypeDef;
 
 /** 
@@ -397,7 +397,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FSMC_Bank1E_TypeDef;
 /** 
   * @brief General Purpose I/O
@@ -405,15 +405,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -422,13 +422,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED;     /*!< Reserved, 0x18                                                               */
-  __IOM uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
-  __IOM uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
+  __IO uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -437,16 +437,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /**
@@ -455,17 +455,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
-  __IOM uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
-  __IOM uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
-  __IOM uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
-  __IOM uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
-  __IOM uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
-  __IOM uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
-  __IOM uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
-  __IOM uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
-  __IOM uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
+  __IO uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
 } FMPI2C_TypeDef;
 
 /** 
@@ -474,10 +474,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -487,8 +487,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -497,40 +497,40 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
   uint32_t      RESERVED7;     /*!< Reserved, 0x88                                                                    */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
-  __IOM uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
-  __IOM uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
 } RCC_TypeDef;
 
 /** 
@@ -539,46 +539,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -587,26 +587,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -615,15 +615,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 /** 
@@ -632,19 +632,19 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
-  __IOM uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
-  __IOM uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
-  __IOM uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
-  __IOM uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
-  __IOM uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
-  __IOM uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
-  __IOM uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
-  __IOM uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
-  __IOM uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
-  __IOM uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
-  __IOM uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
+  __IO uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
+  __IO uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
+  __IO uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
+  __IO uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
+  __IO uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
+  __IO uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
+  __IO uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
+  __IO uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
+  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
+  __IO uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
+  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
 } QUADSPI_TypeDef;
 
 /** 
@@ -653,27 +653,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -682,13 +682,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -697,9 +697,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -708,9 +708,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -718,30 +718,30 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved5[3];             /*!< Reserved                                040h-048h */
-  __IOM uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
+  __IO uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
   uint32_t  Reserved6;                /*!< Reserved                                     050h */
-  __IOM uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
+  __IO uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
   uint32_t  Reserved;                 /*!< Reserved                                     058h */
-  __IOM uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
+  __IO uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
   uint32_t  Reserved43[40];           /*!< Reserved                                058h-0FFh */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -749,26 +749,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -776,13 +776,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -791,12 +791,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -805,13 +805,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -819,12 +819,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f412vx.h
+++ b/Include/stm32f412vx.h
@@ -173,33 +173,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -210,10 +210,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -222,10 +222,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -234,8 +234,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -244,26 +244,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -274,11 +274,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /**
@@ -286,21 +286,21 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t FLTCR1;      /*!< DFSDM control register1,                          Address offset: 0x100 */
-  __IOM uint32_t FLTCR2;      /*!< DFSDM control register2,                          Address offset: 0x104 */
-  __IOM uint32_t FLTISR;      /*!< DFSDM interrupt and status register,              Address offset: 0x108 */
-  __IOM uint32_t FLTICR;      /*!< DFSDM interrupt flag clear register,              Address offset: 0x10C */
-  __IOM uint32_t FLTJCHGR;    /*!< DFSDM injected channel group selection register,  Address offset: 0x110 */
-  __IOM uint32_t FLTFCR;      /*!< DFSDM filter control register,                    Address offset: 0x114 */
-  __IOM uint32_t FLTJDATAR;   /*!< DFSDM data register for injected group,           Address offset: 0x118 */
-  __IOM uint32_t FLTRDATAR;   /*!< DFSDM data register for regular group,            Address offset: 0x11C */
-  __IOM uint32_t FLTAWHTR;    /*!< DFSDM analog watchdog high threshold register,    Address offset: 0x120 */
-  __IOM uint32_t FLTAWLTR;    /*!< DFSDM analog watchdog low threshold register,     Address offset: 0x124 */
-  __IOM uint32_t FLTAWSR;     /*!< DFSDM analog watchdog status register             Address offset: 0x128 */
-  __IOM uint32_t FLTAWCFR;    /*!< DFSDM analog watchdog clear flag register         Address offset: 0x12C */
-  __IOM uint32_t FLTEXMAX;    /*!< DFSDM extreme detector maximum register,          Address offset: 0x130 */
-  __IOM uint32_t FLTEXMIN;    /*!< DFSDM extreme detector minimum register           Address offset: 0x134 */
-  __IOM uint32_t FLTCNVTIMR;  /*!< DFSDM conversion timer,                           Address offset: 0x138 */
+  __IO uint32_t FLTCR1;      /*!< DFSDM control register1,                          Address offset: 0x100 */
+  __IO uint32_t FLTCR2;      /*!< DFSDM control register2,                          Address offset: 0x104 */
+  __IO uint32_t FLTISR;      /*!< DFSDM interrupt and status register,              Address offset: 0x108 */
+  __IO uint32_t FLTICR;      /*!< DFSDM interrupt flag clear register,              Address offset: 0x10C */
+  __IO uint32_t FLTJCHGR;    /*!< DFSDM injected channel group selection register,  Address offset: 0x110 */
+  __IO uint32_t FLTFCR;      /*!< DFSDM filter control register,                    Address offset: 0x114 */
+  __IO uint32_t FLTJDATAR;   /*!< DFSDM data register for injected group,           Address offset: 0x118 */
+  __IO uint32_t FLTRDATAR;   /*!< DFSDM data register for regular group,            Address offset: 0x11C */
+  __IO uint32_t FLTAWHTR;    /*!< DFSDM analog watchdog high threshold register,    Address offset: 0x120 */
+  __IO uint32_t FLTAWLTR;    /*!< DFSDM analog watchdog low threshold register,     Address offset: 0x124 */
+  __IO uint32_t FLTAWSR;     /*!< DFSDM analog watchdog status register             Address offset: 0x128 */
+  __IO uint32_t FLTAWCFR;    /*!< DFSDM analog watchdog clear flag register         Address offset: 0x12C */
+  __IO uint32_t FLTEXMAX;    /*!< DFSDM extreme detector maximum register,          Address offset: 0x130 */
+  __IO uint32_t FLTEXMIN;    /*!< DFSDM extreme detector minimum register           Address offset: 0x134 */
+  __IO uint32_t FLTCNVTIMR;  /*!< DFSDM conversion timer,                           Address offset: 0x138 */
 } DFSDM_Filter_TypeDef;
 
 /**
@@ -308,12 +308,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t CHCFGR1;     /*!< DFSDM channel configuration register1,            Address offset: 0x00 */
-  __IOM uint32_t CHCFGR2;     /*!< DFSDM channel configuration register2,            Address offset: 0x04 */
-  __IOM uint32_t CHAWSCDR;    /*!< DFSDM channel analog watchdog and
+  __IO uint32_t CHCFGR1;     /*!< DFSDM channel configuration register1,            Address offset: 0x00 */
+  __IO uint32_t CHCFGR2;     /*!< DFSDM channel configuration register2,            Address offset: 0x04 */
+  __IO uint32_t CHAWSCDR;    /*!< DFSDM channel analog watchdog and
                                   short circuit detector register,                  Address offset: 0x08 */
-  __IOM uint32_t CHWDATAR;    /*!< DFSDM channel watchdog filter data register,      Address offset: 0x0C */
-  __IOM uint32_t CHDATINR;    /*!< DFSDM channel data input register,                Address offset: 0x10 */
+  __IO uint32_t CHWDATAR;    /*!< DFSDM channel watchdog filter data register,      Address offset: 0x0C */
+  __IO uint32_t CHDATINR;    /*!< DFSDM channel data input register,                Address offset: 0x10 */
 } DFSDM_Channel_TypeDef;
 
 /** 
@@ -322,10 +322,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -335,20 +335,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -357,12 +357,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -371,13 +371,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 
@@ -388,7 +388,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
 } FSMC_Bank1_TypeDef;
 
 /** 
@@ -397,7 +397,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FSMC_Bank1E_TypeDef;
 /** 
   * @brief General Purpose I/O
@@ -405,15 +405,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -422,13 +422,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED;     /*!< Reserved, 0x18                                                               */
-  __IOM uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
-  __IOM uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
+  __IO uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -437,16 +437,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /**
@@ -455,17 +455,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
-  __IOM uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
-  __IOM uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
-  __IOM uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
-  __IOM uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
-  __IOM uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
-  __IOM uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
-  __IOM uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
-  __IOM uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
-  __IOM uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
+  __IO uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
 } FMPI2C_TypeDef;
 
 /** 
@@ -474,10 +474,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -487,8 +487,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -497,40 +497,40 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
   uint32_t      RESERVED7;     /*!< Reserved, 0x88                                                                    */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
-  __IOM uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
-  __IOM uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
 } RCC_TypeDef;
 
 /** 
@@ -539,46 +539,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -587,26 +587,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -615,15 +615,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 /** 
@@ -632,19 +632,19 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
-  __IOM uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
-  __IOM uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
-  __IOM uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
-  __IOM uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
-  __IOM uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
-  __IOM uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
-  __IOM uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
-  __IOM uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
-  __IOM uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
-  __IOM uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
-  __IOM uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
+  __IO uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
+  __IO uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
+  __IO uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
+  __IO uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
+  __IO uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
+  __IO uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
+  __IO uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
+  __IO uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
+  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
+  __IO uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
+  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
 } QUADSPI_TypeDef;
 
 /** 
@@ -653,27 +653,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -682,13 +682,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -697,9 +697,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -708,9 +708,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -718,30 +718,30 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved5[3];             /*!< Reserved                                040h-048h */
-  __IOM uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
+  __IO uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
   uint32_t  Reserved6;                /*!< Reserved                                     050h */
-  __IOM uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
+  __IO uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
   uint32_t  Reserved;                 /*!< Reserved                                     058h */
-  __IOM uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
+  __IO uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
   uint32_t  Reserved43[40];           /*!< Reserved                                058h-0FFh */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -749,26 +749,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -776,13 +776,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -791,12 +791,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -805,13 +805,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -819,12 +819,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f412zx.h
+++ b/Include/stm32f412zx.h
@@ -173,33 +173,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -210,10 +210,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -222,10 +222,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -234,8 +234,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -244,26 +244,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -274,11 +274,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /**
@@ -286,21 +286,21 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t FLTCR1;      /*!< DFSDM control register1,                          Address offset: 0x100 */
-  __IOM uint32_t FLTCR2;      /*!< DFSDM control register2,                          Address offset: 0x104 */
-  __IOM uint32_t FLTISR;      /*!< DFSDM interrupt and status register,              Address offset: 0x108 */
-  __IOM uint32_t FLTICR;      /*!< DFSDM interrupt flag clear register,              Address offset: 0x10C */
-  __IOM uint32_t FLTJCHGR;    /*!< DFSDM injected channel group selection register,  Address offset: 0x110 */
-  __IOM uint32_t FLTFCR;      /*!< DFSDM filter control register,                    Address offset: 0x114 */
-  __IOM uint32_t FLTJDATAR;   /*!< DFSDM data register for injected group,           Address offset: 0x118 */
-  __IOM uint32_t FLTRDATAR;   /*!< DFSDM data register for regular group,            Address offset: 0x11C */
-  __IOM uint32_t FLTAWHTR;    /*!< DFSDM analog watchdog high threshold register,    Address offset: 0x120 */
-  __IOM uint32_t FLTAWLTR;    /*!< DFSDM analog watchdog low threshold register,     Address offset: 0x124 */
-  __IOM uint32_t FLTAWSR;     /*!< DFSDM analog watchdog status register             Address offset: 0x128 */
-  __IOM uint32_t FLTAWCFR;    /*!< DFSDM analog watchdog clear flag register         Address offset: 0x12C */
-  __IOM uint32_t FLTEXMAX;    /*!< DFSDM extreme detector maximum register,          Address offset: 0x130 */
-  __IOM uint32_t FLTEXMIN;    /*!< DFSDM extreme detector minimum register           Address offset: 0x134 */
-  __IOM uint32_t FLTCNVTIMR;  /*!< DFSDM conversion timer,                           Address offset: 0x138 */
+  __IO uint32_t FLTCR1;      /*!< DFSDM control register1,                          Address offset: 0x100 */
+  __IO uint32_t FLTCR2;      /*!< DFSDM control register2,                          Address offset: 0x104 */
+  __IO uint32_t FLTISR;      /*!< DFSDM interrupt and status register,              Address offset: 0x108 */
+  __IO uint32_t FLTICR;      /*!< DFSDM interrupt flag clear register,              Address offset: 0x10C */
+  __IO uint32_t FLTJCHGR;    /*!< DFSDM injected channel group selection register,  Address offset: 0x110 */
+  __IO uint32_t FLTFCR;      /*!< DFSDM filter control register,                    Address offset: 0x114 */
+  __IO uint32_t FLTJDATAR;   /*!< DFSDM data register for injected group,           Address offset: 0x118 */
+  __IO uint32_t FLTRDATAR;   /*!< DFSDM data register for regular group,            Address offset: 0x11C */
+  __IO uint32_t FLTAWHTR;    /*!< DFSDM analog watchdog high threshold register,    Address offset: 0x120 */
+  __IO uint32_t FLTAWLTR;    /*!< DFSDM analog watchdog low threshold register,     Address offset: 0x124 */
+  __IO uint32_t FLTAWSR;     /*!< DFSDM analog watchdog status register             Address offset: 0x128 */
+  __IO uint32_t FLTAWCFR;    /*!< DFSDM analog watchdog clear flag register         Address offset: 0x12C */
+  __IO uint32_t FLTEXMAX;    /*!< DFSDM extreme detector maximum register,          Address offset: 0x130 */
+  __IO uint32_t FLTEXMIN;    /*!< DFSDM extreme detector minimum register           Address offset: 0x134 */
+  __IO uint32_t FLTCNVTIMR;  /*!< DFSDM conversion timer,                           Address offset: 0x138 */
 } DFSDM_Filter_TypeDef;
 
 /**
@@ -308,12 +308,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t CHCFGR1;     /*!< DFSDM channel configuration register1,            Address offset: 0x00 */
-  __IOM uint32_t CHCFGR2;     /*!< DFSDM channel configuration register2,            Address offset: 0x04 */
-  __IOM uint32_t CHAWSCDR;    /*!< DFSDM channel analog watchdog and
+  __IO uint32_t CHCFGR1;     /*!< DFSDM channel configuration register1,            Address offset: 0x00 */
+  __IO uint32_t CHCFGR2;     /*!< DFSDM channel configuration register2,            Address offset: 0x04 */
+  __IO uint32_t CHAWSCDR;    /*!< DFSDM channel analog watchdog and
                                   short circuit detector register,                  Address offset: 0x08 */
-  __IOM uint32_t CHWDATAR;    /*!< DFSDM channel watchdog filter data register,      Address offset: 0x0C */
-  __IOM uint32_t CHDATINR;    /*!< DFSDM channel data input register,                Address offset: 0x10 */
+  __IO uint32_t CHWDATAR;    /*!< DFSDM channel watchdog filter data register,      Address offset: 0x0C */
+  __IO uint32_t CHDATINR;    /*!< DFSDM channel data input register,                Address offset: 0x10 */
 } DFSDM_Channel_TypeDef;
 
 /** 
@@ -322,10 +322,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -335,20 +335,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -357,12 +357,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -371,13 +371,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 
@@ -388,7 +388,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
 } FSMC_Bank1_TypeDef;
 
 /** 
@@ -397,7 +397,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FSMC_Bank1E_TypeDef;
 /** 
   * @brief General Purpose I/O
@@ -405,15 +405,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -422,13 +422,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED;     /*!< Reserved, 0x18                                                               */
-  __IOM uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
-  __IOM uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
+  __IO uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x24      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -437,16 +437,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /**
@@ -455,17 +455,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
-  __IOM uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
-  __IOM uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
-  __IOM uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
-  __IOM uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
-  __IOM uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
-  __IOM uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
-  __IOM uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
-  __IOM uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
-  __IOM uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
+  __IO uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
 } FMPI2C_TypeDef;
 
 /** 
@@ -474,10 +474,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -487,8 +487,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -497,40 +497,40 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
   uint32_t      RESERVED7;     /*!< Reserved, 0x88                                                                    */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
-  __IOM uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
-  __IOM uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                           Address offset: 0x90  */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
 } RCC_TypeDef;
 
 /** 
@@ -539,46 +539,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -587,26 +587,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -615,15 +615,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 /** 
@@ -632,19 +632,19 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
-  __IOM uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
-  __IOM uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
-  __IOM uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
-  __IOM uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
-  __IOM uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
-  __IOM uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
-  __IOM uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
-  __IOM uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
-  __IOM uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
-  __IOM uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
-  __IOM uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
+  __IO uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
+  __IO uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
+  __IO uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
+  __IO uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
+  __IO uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
+  __IO uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
+  __IO uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
+  __IO uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
+  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
+  __IO uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
+  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
 } QUADSPI_TypeDef;
 
 /** 
@@ -653,27 +653,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -682,13 +682,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -697,9 +697,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -708,9 +708,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -718,30 +718,30 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved5[3];             /*!< Reserved                                040h-048h */
-  __IOM uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
+  __IO uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
   uint32_t  Reserved6;                /*!< Reserved                                     050h */
-  __IOM uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
+  __IO uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
   uint32_t  Reserved;                 /*!< Reserved                                     058h */
-  __IOM uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
+  __IO uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
   uint32_t  Reserved43[40];           /*!< Reserved                                058h-0FFh */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -749,26 +749,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -776,13 +776,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -791,12 +791,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -805,13 +805,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -819,12 +819,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f413xx.h
+++ b/Include/stm32f413xx.h
@@ -189,33 +189,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -226,10 +226,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -238,10 +238,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -250,8 +250,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -260,26 +260,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -290,11 +290,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /**
@@ -302,21 +302,21 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t FLTCR1;      /*!< DFSDM control register1,                          Address offset: 0x100 */
-  __IOM uint32_t FLTCR2;      /*!< DFSDM control register2,                          Address offset: 0x104 */
-  __IOM uint32_t FLTISR;      /*!< DFSDM interrupt and status register,              Address offset: 0x108 */
-  __IOM uint32_t FLTICR;      /*!< DFSDM interrupt flag clear register,              Address offset: 0x10C */
-  __IOM uint32_t FLTJCHGR;    /*!< DFSDM injected channel group selection register,  Address offset: 0x110 */
-  __IOM uint32_t FLTFCR;      /*!< DFSDM filter control register,                    Address offset: 0x114 */
-  __IOM uint32_t FLTJDATAR;   /*!< DFSDM data register for injected group,           Address offset: 0x118 */
-  __IOM uint32_t FLTRDATAR;   /*!< DFSDM data register for regular group,            Address offset: 0x11C */
-  __IOM uint32_t FLTAWHTR;    /*!< DFSDM analog watchdog high threshold register,    Address offset: 0x120 */
-  __IOM uint32_t FLTAWLTR;    /*!< DFSDM analog watchdog low threshold register,     Address offset: 0x124 */
-  __IOM uint32_t FLTAWSR;     /*!< DFSDM analog watchdog status register             Address offset: 0x128 */
-  __IOM uint32_t FLTAWCFR;    /*!< DFSDM analog watchdog clear flag register         Address offset: 0x12C */
-  __IOM uint32_t FLTEXMAX;    /*!< DFSDM extreme detector maximum register,          Address offset: 0x130 */
-  __IOM uint32_t FLTEXMIN;    /*!< DFSDM extreme detector minimum register           Address offset: 0x134 */
-  __IOM uint32_t FLTCNVTIMR;  /*!< DFSDM conversion timer,                           Address offset: 0x138 */
+  __IO uint32_t FLTCR1;      /*!< DFSDM control register1,                          Address offset: 0x100 */
+  __IO uint32_t FLTCR2;      /*!< DFSDM control register2,                          Address offset: 0x104 */
+  __IO uint32_t FLTISR;      /*!< DFSDM interrupt and status register,              Address offset: 0x108 */
+  __IO uint32_t FLTICR;      /*!< DFSDM interrupt flag clear register,              Address offset: 0x10C */
+  __IO uint32_t FLTJCHGR;    /*!< DFSDM injected channel group selection register,  Address offset: 0x110 */
+  __IO uint32_t FLTFCR;      /*!< DFSDM filter control register,                    Address offset: 0x114 */
+  __IO uint32_t FLTJDATAR;   /*!< DFSDM data register for injected group,           Address offset: 0x118 */
+  __IO uint32_t FLTRDATAR;   /*!< DFSDM data register for regular group,            Address offset: 0x11C */
+  __IO uint32_t FLTAWHTR;    /*!< DFSDM analog watchdog high threshold register,    Address offset: 0x120 */
+  __IO uint32_t FLTAWLTR;    /*!< DFSDM analog watchdog low threshold register,     Address offset: 0x124 */
+  __IO uint32_t FLTAWSR;     /*!< DFSDM analog watchdog status register             Address offset: 0x128 */
+  __IO uint32_t FLTAWCFR;    /*!< DFSDM analog watchdog clear flag register         Address offset: 0x12C */
+  __IO uint32_t FLTEXMAX;    /*!< DFSDM extreme detector maximum register,          Address offset: 0x130 */
+  __IO uint32_t FLTEXMIN;    /*!< DFSDM extreme detector minimum register           Address offset: 0x134 */
+  __IO uint32_t FLTCNVTIMR;  /*!< DFSDM conversion timer,                           Address offset: 0x138 */
 } DFSDM_Filter_TypeDef;
 
 /**
@@ -324,12 +324,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t CHCFGR1;     /*!< DFSDM channel configuration register1,            Address offset: 0x00 */
-  __IOM uint32_t CHCFGR2;     /*!< DFSDM channel configuration register2,            Address offset: 0x04 */
-  __IOM uint32_t CHAWSCDR;    /*!< DFSDM channel analog watchdog and
+  __IO uint32_t CHCFGR1;     /*!< DFSDM channel configuration register1,            Address offset: 0x00 */
+  __IO uint32_t CHCFGR2;     /*!< DFSDM channel configuration register2,            Address offset: 0x04 */
+  __IO uint32_t CHAWSCDR;    /*!< DFSDM channel analog watchdog and
                                   short circuit detector register,                  Address offset: 0x08 */
-  __IOM uint32_t CHWDATAR;    /*!< DFSDM channel watchdog filter data register,      Address offset: 0x0C */
-  __IOM uint32_t CHDATINR;    /*!< DFSDM channel data input register,                Address offset: 0x10 */
+  __IO uint32_t CHWDATAR;    /*!< DFSDM channel watchdog filter data register,      Address offset: 0x0C */
+  __IO uint32_t CHDATINR;    /*!< DFSDM channel data input register,                Address offset: 0x10 */
 } DFSDM_Channel_TypeDef;
 
 /** 
@@ -338,20 +338,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -360,10 +360,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -373,20 +373,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -395,12 +395,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -409,13 +409,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 
@@ -426,7 +426,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
 } FSMC_Bank1_TypeDef;
 
 /** 
@@ -435,7 +435,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FSMC_Bank1E_TypeDef;
 /** 
   * @brief General Purpose I/O
@@ -443,15 +443,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -460,15 +460,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED;     /*!< Reserved, 0x18                                                               */
-  __IOM uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
   uint32_t      RESERVED1[2]; /*!< Reserved, 0x24-0x28                                                          */
-  __IOM uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x2C      */
-  __IOM uint32_t MCHDLYCR;     /*!< SYSCFG multi-channel delay register,               Address offset: 0x30      */
+  __IO uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x2C      */
+  __IO uint32_t MCHDLYCR;     /*!< SYSCFG multi-channel delay register,               Address offset: 0x30      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -477,16 +477,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /**
@@ -495,17 +495,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
-  __IOM uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
-  __IOM uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
-  __IOM uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
-  __IOM uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
-  __IOM uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
-  __IOM uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
-  __IOM uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
-  __IOM uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
-  __IOM uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
+  __IO uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
 } FMPI2C_TypeDef;
 
 /** 
@@ -514,10 +514,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -527,8 +527,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -537,40 +537,40 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
   uint32_t      RESERVED7;     /*!< Reserved, 0x84                                                                    */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
-  __IOM uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                            Address offset: 0x90 */
-  __IOM uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                            Address offset: 0x90 */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
 } RCC_TypeDef;
 
 /** 
@@ -579,46 +579,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -627,19 +627,19 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
+  __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
 } SAI_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
-  __IOM uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
-  __IOM uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
-  __IOM uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
-  __IOM uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
-  __IOM uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
-  __IOM uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
+  __IO uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
+  __IO uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
+  __IO uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
+  __IO uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
+  __IO uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
+  __IO uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
+  __IO uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
 } SAI_Block_TypeDef;
 
 /** 
@@ -648,26 +648,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -676,15 +676,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 /** 
@@ -693,19 +693,19 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
-  __IOM uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
-  __IOM uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
-  __IOM uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
-  __IOM uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
-  __IOM uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
-  __IOM uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
-  __IOM uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
-  __IOM uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
-  __IOM uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
-  __IOM uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
-  __IOM uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
+  __IO uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
+  __IO uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
+  __IO uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
+  __IO uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
+  __IO uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
+  __IO uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
+  __IO uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
+  __IO uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
+  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
+  __IO uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
+  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
 } QUADSPI_TypeDef;
 
 /** 
@@ -714,27 +714,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -743,13 +743,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -758,9 +758,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -769,9 +769,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -779,30 +779,30 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved5[3];             /*!< Reserved                                040h-048h */
-  __IOM uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
+  __IO uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
   uint32_t  Reserved6;                /*!< Reserved                                     050h */
-  __IOM uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
+  __IO uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
   uint32_t  Reserved;                 /*!< Reserved                                     058h */
-  __IOM uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
+  __IO uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
   uint32_t  Reserved43[40];           /*!< Reserved                                058h-0FFh */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -810,26 +810,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -837,13 +837,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -852,12 +852,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -866,13 +866,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -880,12 +880,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 
@@ -894,15 +894,15 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
-  __IOM uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
-  __IOM uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
-  __IOM uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
-  __IOM uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
-  __IOM uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
-  __IOM uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
-  __IOM uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
-  __IOM uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
+  __IO uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
 } LPTIM_TypeDef;
 
 /**

--- a/Include/stm32f415xx.h
+++ b/Include/stm32f415xx.h
@@ -174,33 +174,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -211,10 +211,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -223,10 +223,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -235,8 +235,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -245,26 +245,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -275,11 +275,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -288,20 +288,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -310,10 +310,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -323,20 +323,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -345,12 +345,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -359,13 +359,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 
@@ -376,7 +376,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
 } FSMC_Bank1_TypeDef;
 
 /** 
@@ -385,7 +385,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FSMC_Bank1E_TypeDef;
 
 /** 
@@ -394,20 +394,20 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
-  __IOM uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
-  __IOM uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
-  __IOM uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
+  __IO uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
+  __IO uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
+  __IO uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
+  __IO uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
   uint32_t      RESERVED0;  /*!< Reserved, 0x70                                                            */
-  __IOM uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
+  __IO uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
   uint32_t      RESERVED1;  /*!< Reserved, 0x78                                                            */
   uint32_t      RESERVED2;  /*!< Reserved, 0x7C                                                            */
-  __IOM uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
-  __IOM uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
-  __IOM uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
-  __IOM uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
+  __IO uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
+  __IO uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
+  __IO uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
+  __IO uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
   uint32_t      RESERVED3;  /*!< Reserved, 0x90                                                            */
-  __IOM uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
+  __IO uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
 } FSMC_Bank2_3_TypeDef;
 
 /** 
@@ -416,11 +416,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
-  __IOM uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
-  __IOM uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
-  __IOM uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
-  __IOM uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
+  __IO uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
+  __IO uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
+  __IO uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
+  __IO uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
+  __IO uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
 } FSMC_Bank4_TypeDef; 
 
 /** 
@@ -429,15 +429,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -446,11 +446,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -459,15 +459,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
 } I2C_TypeDef;
 
 /** 
@@ -476,10 +476,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -489,8 +489,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -499,36 +499,36 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
 } RCC_TypeDef;
 
 /** 
@@ -537,46 +537,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -585,26 +585,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -613,15 +613,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -631,27 +631,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -660,13 +660,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -675,9 +675,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -686,42 +686,42 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;         /*!< CRYP control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SR;         /*!< CRYP status register,                                     Address offset: 0x04 */
-  __IOM uint32_t DIN;         /*!< CRYP data input register,                                 Address offset: 0x08 */
-  __IOM uint32_t DOUT;       /*!< CRYP data output register,                                Address offset: 0x0C */
-  __IOM uint32_t DMACR;      /*!< CRYP DMA control register,                                Address offset: 0x10 */
-  __IOM uint32_t IMSCR;      /*!< CRYP interrupt mask set/clear register,                   Address offset: 0x14 */
-  __IOM uint32_t RISR;       /*!< CRYP raw interrupt status register,                       Address offset: 0x18 */
-  __IOM uint32_t MISR;       /*!< CRYP masked interrupt status register,                    Address offset: 0x1C */
-  __IOM uint32_t K0LR;       /*!< CRYP key left  register 0,                                Address offset: 0x20 */
-  __IOM uint32_t K0RR;       /*!< CRYP key right register 0,                                Address offset: 0x24 */
-  __IOM uint32_t K1LR;       /*!< CRYP key left  register 1,                                Address offset: 0x28 */
-  __IOM uint32_t K1RR;       /*!< CRYP key right register 1,                                Address offset: 0x2C */
-  __IOM uint32_t K2LR;       /*!< CRYP key left  register 2,                                Address offset: 0x30 */
-  __IOM uint32_t K2RR;       /*!< CRYP key right register 2,                                Address offset: 0x34 */
-  __IOM uint32_t K3LR;       /*!< CRYP key left  register 3,                                Address offset: 0x38 */
-  __IOM uint32_t K3RR;       /*!< CRYP key right register 3,                                Address offset: 0x3C */
-  __IOM uint32_t IV0LR;      /*!< CRYP initialization vector left-word  register 0,         Address offset: 0x40 */
-  __IOM uint32_t IV0RR;      /*!< CRYP initialization vector right-word register 0,         Address offset: 0x44 */
-  __IOM uint32_t IV1LR;      /*!< CRYP initialization vector left-word  register 1,         Address offset: 0x48 */
-  __IOM uint32_t IV1RR;      /*!< CRYP initialization vector right-word register 1,         Address offset: 0x4C */
-  __IOM uint32_t CSGCMCCM0R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 0,        Address offset: 0x50 */
-  __IOM uint32_t CSGCMCCM1R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 1,        Address offset: 0x54 */
-  __IOM uint32_t CSGCMCCM2R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 2,        Address offset: 0x58 */
-  __IOM uint32_t CSGCMCCM3R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 3,        Address offset: 0x5C */
-  __IOM uint32_t CSGCMCCM4R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 4,        Address offset: 0x60 */
-  __IOM uint32_t CSGCMCCM5R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 5,        Address offset: 0x64 */
-  __IOM uint32_t CSGCMCCM6R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 6,        Address offset: 0x68 */
-  __IOM uint32_t CSGCMCCM7R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 7,        Address offset: 0x6C */
-  __IOM uint32_t CSGCM0R;    /*!< CRYP GCM/GMAC context swap register 0,                    Address offset: 0x70 */
-  __IOM uint32_t CSGCM1R;    /*!< CRYP GCM/GMAC context swap register 1,                    Address offset: 0x74 */
-  __IOM uint32_t CSGCM2R;    /*!< CRYP GCM/GMAC context swap register 2,                    Address offset: 0x78 */
-  __IOM uint32_t CSGCM3R;    /*!< CRYP GCM/GMAC context swap register 3,                    Address offset: 0x7C */
-  __IOM uint32_t CSGCM4R;    /*!< CRYP GCM/GMAC context swap register 4,                    Address offset: 0x80 */
-  __IOM uint32_t CSGCM5R;    /*!< CRYP GCM/GMAC context swap register 5,                    Address offset: 0x84 */
-  __IOM uint32_t CSGCM6R;    /*!< CRYP GCM/GMAC context swap register 6,                    Address offset: 0x88 */
-  __IOM uint32_t CSGCM7R;    /*!< CRYP GCM/GMAC context swap register 7,                    Address offset: 0x8C */
+  __IO uint32_t CR;         /*!< CRYP control register,                                    Address offset: 0x00 */
+  __IO uint32_t SR;         /*!< CRYP status register,                                     Address offset: 0x04 */
+  __IO uint32_t DIN;         /*!< CRYP data input register,                                 Address offset: 0x08 */
+  __IO uint32_t DOUT;       /*!< CRYP data output register,                                Address offset: 0x0C */
+  __IO uint32_t DMACR;      /*!< CRYP DMA control register,                                Address offset: 0x10 */
+  __IO uint32_t IMSCR;      /*!< CRYP interrupt mask set/clear register,                   Address offset: 0x14 */
+  __IO uint32_t RISR;       /*!< CRYP raw interrupt status register,                       Address offset: 0x18 */
+  __IO uint32_t MISR;       /*!< CRYP masked interrupt status register,                    Address offset: 0x1C */
+  __IO uint32_t K0LR;       /*!< CRYP key left  register 0,                                Address offset: 0x20 */
+  __IO uint32_t K0RR;       /*!< CRYP key right register 0,                                Address offset: 0x24 */
+  __IO uint32_t K1LR;       /*!< CRYP key left  register 1,                                Address offset: 0x28 */
+  __IO uint32_t K1RR;       /*!< CRYP key right register 1,                                Address offset: 0x2C */
+  __IO uint32_t K2LR;       /*!< CRYP key left  register 2,                                Address offset: 0x30 */
+  __IO uint32_t K2RR;       /*!< CRYP key right register 2,                                Address offset: 0x34 */
+  __IO uint32_t K3LR;       /*!< CRYP key left  register 3,                                Address offset: 0x38 */
+  __IO uint32_t K3RR;       /*!< CRYP key right register 3,                                Address offset: 0x3C */
+  __IO uint32_t IV0LR;      /*!< CRYP initialization vector left-word  register 0,         Address offset: 0x40 */
+  __IO uint32_t IV0RR;      /*!< CRYP initialization vector right-word register 0,         Address offset: 0x44 */
+  __IO uint32_t IV1LR;      /*!< CRYP initialization vector left-word  register 1,         Address offset: 0x48 */
+  __IO uint32_t IV1RR;      /*!< CRYP initialization vector right-word register 1,         Address offset: 0x4C */
+  __IO uint32_t CSGCMCCM0R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 0,        Address offset: 0x50 */
+  __IO uint32_t CSGCMCCM1R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 1,        Address offset: 0x54 */
+  __IO uint32_t CSGCMCCM2R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 2,        Address offset: 0x58 */
+  __IO uint32_t CSGCMCCM3R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 3,        Address offset: 0x5C */
+  __IO uint32_t CSGCMCCM4R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 4,        Address offset: 0x60 */
+  __IO uint32_t CSGCMCCM5R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 5,        Address offset: 0x64 */
+  __IO uint32_t CSGCMCCM6R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 6,        Address offset: 0x68 */
+  __IO uint32_t CSGCMCCM7R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 7,        Address offset: 0x6C */
+  __IO uint32_t CSGCM0R;    /*!< CRYP GCM/GMAC context swap register 0,                    Address offset: 0x70 */
+  __IO uint32_t CSGCM1R;    /*!< CRYP GCM/GMAC context swap register 1,                    Address offset: 0x74 */
+  __IO uint32_t CSGCM2R;    /*!< CRYP GCM/GMAC context swap register 2,                    Address offset: 0x78 */
+  __IO uint32_t CSGCM3R;    /*!< CRYP GCM/GMAC context swap register 3,                    Address offset: 0x7C */
+  __IO uint32_t CSGCM4R;    /*!< CRYP GCM/GMAC context swap register 4,                    Address offset: 0x80 */
+  __IO uint32_t CSGCM5R;    /*!< CRYP GCM/GMAC context swap register 5,                    Address offset: 0x84 */
+  __IO uint32_t CSGCM6R;    /*!< CRYP GCM/GMAC context swap register 6,                    Address offset: 0x88 */
+  __IO uint32_t CSGCM7R;    /*!< CRYP GCM/GMAC context swap register 7,                    Address offset: 0x8C */
 } CRYP_TypeDef;
 
 /** 
@@ -730,14 +730,14 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;               /*!< HASH control register,          Address offset: 0x00        */
-  __IOM uint32_t DIN;              /*!< HASH data input register,       Address offset: 0x04        */
-  __IOM uint32_t STR;              /*!< HASH start register,            Address offset: 0x08        */
-  __IOM uint32_t HR[5];            /*!< HASH digest registers,          Address offset: 0x0C-0x1C   */
-  __IOM uint32_t IMR;              /*!< HASH interrupt enable register, Address offset: 0x20        */
-  __IOM uint32_t SR;               /*!< HASH status register,           Address offset: 0x24        */
+  __IO uint32_t CR;               /*!< HASH control register,          Address offset: 0x00        */
+  __IO uint32_t DIN;              /*!< HASH data input register,       Address offset: 0x04        */
+  __IO uint32_t STR;              /*!< HASH start register,            Address offset: 0x08        */
+  __IO uint32_t HR[5];            /*!< HASH digest registers,          Address offset: 0x0C-0x1C   */
+  __IO uint32_t IMR;              /*!< HASH interrupt enable register, Address offset: 0x20        */
+  __IO uint32_t SR;               /*!< HASH status register,           Address offset: 0x24        */
        uint32_t RESERVED[52];     /*!< Reserved, 0x28-0xF4                                         */
-  __IOM uint32_t CSR[54];          /*!< HASH context swap registers,    Address offset: 0x0F8-0x1CC */
+  __IO uint32_t CSR[54];          /*!< HASH context swap registers,    Address offset: 0x0F8-0x1CC */
 } HASH_TypeDef;
 
 /** 
@@ -746,7 +746,7 @@ typedef struct
 
 typedef struct 
 {
-  __IOM uint32_t HR[5];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */ 
+  __IO uint32_t HR[5];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */ 
 } HASH_DIGEST_TypeDef;
 
 /** 
@@ -755,9 +755,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -765,24 +765,24 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved40[48];           /*!< Reserved                                0x40-0xFF */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -790,26 +790,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -817,13 +817,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -832,12 +832,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -846,13 +846,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -860,12 +860,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f417xx.h
+++ b/Include/stm32f417xx.h
@@ -177,33 +177,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -214,10 +214,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -226,10 +226,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -238,8 +238,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -248,26 +248,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -278,11 +278,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -291,20 +291,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -313,10 +313,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 /** 
@@ -325,17 +325,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
-  __IOM uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
-  __IOM uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
-  __IOM uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
-  __IOM uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
-  __IOM uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
-  __IOM uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
-  __IOM uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
-  __IOM uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
-  __IOM uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
-  __IOM uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
+  __IO uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
+  __IO uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
+  __IO uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
+  __IO uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
+  __IO uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
+  __IO uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
+  __IO uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
+  __IO uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
+  __IO uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
+  __IO uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
+  __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
 } DCMI_TypeDef;
 
 /** 
@@ -344,20 +344,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -366,73 +366,73 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MACCR;
-  __IOM uint32_t MACFFR;
-  __IOM uint32_t MACHTHR;
-  __IOM uint32_t MACHTLR;
-  __IOM uint32_t MACMIIAR;
-  __IOM uint32_t MACMIIDR;
-  __IOM uint32_t MACFCR;
-  __IOM uint32_t MACVLANTR;             /*    8 */
+  __IO uint32_t MACCR;
+  __IO uint32_t MACFFR;
+  __IO uint32_t MACHTHR;
+  __IO uint32_t MACHTLR;
+  __IO uint32_t MACMIIAR;
+  __IO uint32_t MACMIIDR;
+  __IO uint32_t MACFCR;
+  __IO uint32_t MACVLANTR;             /*    8 */
   uint32_t      RESERVED0[2];
-  __IOM uint32_t MACRWUFFR;             /*   11 */
-  __IOM uint32_t MACPMTCSR;
+  __IO uint32_t MACRWUFFR;             /*   11 */
+  __IO uint32_t MACPMTCSR;
   uint32_t      RESERVED1;
-  __IOM uint32_t MACDBGR;
-  __IOM uint32_t MACSR;                 /*   15 */
-  __IOM uint32_t MACIMR;
-  __IOM uint32_t MACA0HR;
-  __IOM uint32_t MACA0LR;
-  __IOM uint32_t MACA1HR;
-  __IOM uint32_t MACA1LR;
-  __IOM uint32_t MACA2HR;
-  __IOM uint32_t MACA2LR;
-  __IOM uint32_t MACA3HR;
-  __IOM uint32_t MACA3LR;               /*   24 */
+  __IO uint32_t MACDBGR;
+  __IO uint32_t MACSR;                 /*   15 */
+  __IO uint32_t MACIMR;
+  __IO uint32_t MACA0HR;
+  __IO uint32_t MACA0LR;
+  __IO uint32_t MACA1HR;
+  __IO uint32_t MACA1LR;
+  __IO uint32_t MACA2HR;
+  __IO uint32_t MACA2LR;
+  __IO uint32_t MACA3HR;
+  __IO uint32_t MACA3LR;               /*   24 */
   uint32_t      RESERVED2[40];
-  __IOM uint32_t MMCCR;                 /*   65 */
-  __IOM uint32_t MMCRIR;
-  __IOM uint32_t MMCTIR;
-  __IOM uint32_t MMCRIMR;
-  __IOM uint32_t MMCTIMR;               /*   69 */
+  __IO uint32_t MMCCR;                 /*   65 */
+  __IO uint32_t MMCRIR;
+  __IO uint32_t MMCTIR;
+  __IO uint32_t MMCRIMR;
+  __IO uint32_t MMCTIMR;               /*   69 */
   uint32_t      RESERVED3[14];
-  __IOM uint32_t MMCTGFSCCR;            /*   84 */
-  __IOM uint32_t MMCTGFMSCCR;
+  __IO uint32_t MMCTGFSCCR;            /*   84 */
+  __IO uint32_t MMCTGFMSCCR;
   uint32_t      RESERVED4[5];
-  __IOM uint32_t MMCTGFCR;
+  __IO uint32_t MMCTGFCR;
   uint32_t      RESERVED5[10];
-  __IOM uint32_t MMCRFCECR;
-  __IOM uint32_t MMCRFAECR;
+  __IO uint32_t MMCRFCECR;
+  __IO uint32_t MMCRFAECR;
   uint32_t      RESERVED6[10];
-  __IOM uint32_t MMCRGUFCR;
+  __IO uint32_t MMCRGUFCR;
   uint32_t      RESERVED7[334];
-  __IOM uint32_t PTPTSCR;
-  __IOM uint32_t PTPSSIR;
-  __IOM uint32_t PTPTSHR;
-  __IOM uint32_t PTPTSLR;
-  __IOM uint32_t PTPTSHUR;
-  __IOM uint32_t PTPTSLUR;
-  __IOM uint32_t PTPTSAR;
-  __IOM uint32_t PTPTTHR;
-  __IOM uint32_t PTPTTLR;
-  __IOM uint32_t RESERVED8;
-  __IOM uint32_t PTPTSSR;
+  __IO uint32_t PTPTSCR;
+  __IO uint32_t PTPSSIR;
+  __IO uint32_t PTPTSHR;
+  __IO uint32_t PTPTSLR;
+  __IO uint32_t PTPTSHUR;
+  __IO uint32_t PTPTSLUR;
+  __IO uint32_t PTPTSAR;
+  __IO uint32_t PTPTTHR;
+  __IO uint32_t PTPTTLR;
+  __IO uint32_t RESERVED8;
+  __IO uint32_t PTPTSSR;
   uint32_t      RESERVED9[565];
-  __IOM uint32_t DMABMR;
-  __IOM uint32_t DMATPDR;
-  __IOM uint32_t DMARPDR;
-  __IOM uint32_t DMARDLAR;
-  __IOM uint32_t DMATDLAR;
-  __IOM uint32_t DMASR;
-  __IOM uint32_t DMAOMR;
-  __IOM uint32_t DMAIER;
-  __IOM uint32_t DMAMFBOCR;
-  __IOM uint32_t DMARSWTR;
+  __IO uint32_t DMABMR;
+  __IO uint32_t DMATPDR;
+  __IO uint32_t DMARPDR;
+  __IO uint32_t DMARDLAR;
+  __IO uint32_t DMATDLAR;
+  __IO uint32_t DMASR;
+  __IO uint32_t DMAOMR;
+  __IO uint32_t DMAIER;
+  __IO uint32_t DMAMFBOCR;
+  __IO uint32_t DMARSWTR;
   uint32_t      RESERVED10[8];
-  __IOM uint32_t DMACHTDR;
-  __IOM uint32_t DMACHRDR;
-  __IOM uint32_t DMACHTBAR;
-  __IOM uint32_t DMACHRBAR;
+  __IO uint32_t DMACHTDR;
+  __IO uint32_t DMACHRDR;
+  __IO uint32_t DMACHTBAR;
+  __IO uint32_t DMACHRBAR;
 } ETH_TypeDef;
 
 /** 
@@ -441,12 +441,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -455,13 +455,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 
@@ -472,7 +472,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
 } FSMC_Bank1_TypeDef;
 
 /** 
@@ -481,7 +481,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FSMC_Bank1E_TypeDef;
 
 /** 
@@ -490,20 +490,20 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
-  __IOM uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
-  __IOM uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
-  __IOM uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
+  __IO uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
+  __IO uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
+  __IO uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
+  __IO uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
   uint32_t      RESERVED0;  /*!< Reserved, 0x70                                                            */
-  __IOM uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
+  __IO uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
   uint32_t      RESERVED1;  /*!< Reserved, 0x78                                                            */
   uint32_t      RESERVED2;  /*!< Reserved, 0x7C                                                            */
-  __IOM uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
-  __IOM uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
-  __IOM uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
-  __IOM uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
+  __IO uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
+  __IO uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
+  __IO uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
+  __IO uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
   uint32_t      RESERVED3;  /*!< Reserved, 0x90                                                            */
-  __IOM uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
+  __IO uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
 } FSMC_Bank2_3_TypeDef;
 
 /** 
@@ -512,11 +512,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
-  __IOM uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
-  __IOM uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
-  __IOM uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
-  __IOM uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
+  __IO uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
+  __IO uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
+  __IO uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
+  __IO uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
+  __IO uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
 } FSMC_Bank4_TypeDef; 
 
 /** 
@@ -525,15 +525,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -542,11 +542,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -555,15 +555,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
 } I2C_TypeDef;
 
 /** 
@@ -572,10 +572,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -585,8 +585,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -595,36 +595,36 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
 } RCC_TypeDef;
 
 /** 
@@ -633,46 +633,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -681,26 +681,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -709,15 +709,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -727,27 +727,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -756,13 +756,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -771,9 +771,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -782,42 +782,42 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;         /*!< CRYP control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SR;         /*!< CRYP status register,                                     Address offset: 0x04 */
-  __IOM uint32_t DIN;         /*!< CRYP data input register,                                 Address offset: 0x08 */
-  __IOM uint32_t DOUT;       /*!< CRYP data output register,                                Address offset: 0x0C */
-  __IOM uint32_t DMACR;      /*!< CRYP DMA control register,                                Address offset: 0x10 */
-  __IOM uint32_t IMSCR;      /*!< CRYP interrupt mask set/clear register,                   Address offset: 0x14 */
-  __IOM uint32_t RISR;       /*!< CRYP raw interrupt status register,                       Address offset: 0x18 */
-  __IOM uint32_t MISR;       /*!< CRYP masked interrupt status register,                    Address offset: 0x1C */
-  __IOM uint32_t K0LR;       /*!< CRYP key left  register 0,                                Address offset: 0x20 */
-  __IOM uint32_t K0RR;       /*!< CRYP key right register 0,                                Address offset: 0x24 */
-  __IOM uint32_t K1LR;       /*!< CRYP key left  register 1,                                Address offset: 0x28 */
-  __IOM uint32_t K1RR;       /*!< CRYP key right register 1,                                Address offset: 0x2C */
-  __IOM uint32_t K2LR;       /*!< CRYP key left  register 2,                                Address offset: 0x30 */
-  __IOM uint32_t K2RR;       /*!< CRYP key right register 2,                                Address offset: 0x34 */
-  __IOM uint32_t K3LR;       /*!< CRYP key left  register 3,                                Address offset: 0x38 */
-  __IOM uint32_t K3RR;       /*!< CRYP key right register 3,                                Address offset: 0x3C */
-  __IOM uint32_t IV0LR;      /*!< CRYP initialization vector left-word  register 0,         Address offset: 0x40 */
-  __IOM uint32_t IV0RR;      /*!< CRYP initialization vector right-word register 0,         Address offset: 0x44 */
-  __IOM uint32_t IV1LR;      /*!< CRYP initialization vector left-word  register 1,         Address offset: 0x48 */
-  __IOM uint32_t IV1RR;      /*!< CRYP initialization vector right-word register 1,         Address offset: 0x4C */
-  __IOM uint32_t CSGCMCCM0R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 0,        Address offset: 0x50 */
-  __IOM uint32_t CSGCMCCM1R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 1,        Address offset: 0x54 */
-  __IOM uint32_t CSGCMCCM2R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 2,        Address offset: 0x58 */
-  __IOM uint32_t CSGCMCCM3R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 3,        Address offset: 0x5C */
-  __IOM uint32_t CSGCMCCM4R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 4,        Address offset: 0x60 */
-  __IOM uint32_t CSGCMCCM5R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 5,        Address offset: 0x64 */
-  __IOM uint32_t CSGCMCCM6R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 6,        Address offset: 0x68 */
-  __IOM uint32_t CSGCMCCM7R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 7,        Address offset: 0x6C */
-  __IOM uint32_t CSGCM0R;    /*!< CRYP GCM/GMAC context swap register 0,                    Address offset: 0x70 */
-  __IOM uint32_t CSGCM1R;    /*!< CRYP GCM/GMAC context swap register 1,                    Address offset: 0x74 */
-  __IOM uint32_t CSGCM2R;    /*!< CRYP GCM/GMAC context swap register 2,                    Address offset: 0x78 */
-  __IOM uint32_t CSGCM3R;    /*!< CRYP GCM/GMAC context swap register 3,                    Address offset: 0x7C */
-  __IOM uint32_t CSGCM4R;    /*!< CRYP GCM/GMAC context swap register 4,                    Address offset: 0x80 */
-  __IOM uint32_t CSGCM5R;    /*!< CRYP GCM/GMAC context swap register 5,                    Address offset: 0x84 */
-  __IOM uint32_t CSGCM6R;    /*!< CRYP GCM/GMAC context swap register 6,                    Address offset: 0x88 */
-  __IOM uint32_t CSGCM7R;    /*!< CRYP GCM/GMAC context swap register 7,                    Address offset: 0x8C */
+  __IO uint32_t CR;         /*!< CRYP control register,                                    Address offset: 0x00 */
+  __IO uint32_t SR;         /*!< CRYP status register,                                     Address offset: 0x04 */
+  __IO uint32_t DIN;         /*!< CRYP data input register,                                 Address offset: 0x08 */
+  __IO uint32_t DOUT;       /*!< CRYP data output register,                                Address offset: 0x0C */
+  __IO uint32_t DMACR;      /*!< CRYP DMA control register,                                Address offset: 0x10 */
+  __IO uint32_t IMSCR;      /*!< CRYP interrupt mask set/clear register,                   Address offset: 0x14 */
+  __IO uint32_t RISR;       /*!< CRYP raw interrupt status register,                       Address offset: 0x18 */
+  __IO uint32_t MISR;       /*!< CRYP masked interrupt status register,                    Address offset: 0x1C */
+  __IO uint32_t K0LR;       /*!< CRYP key left  register 0,                                Address offset: 0x20 */
+  __IO uint32_t K0RR;       /*!< CRYP key right register 0,                                Address offset: 0x24 */
+  __IO uint32_t K1LR;       /*!< CRYP key left  register 1,                                Address offset: 0x28 */
+  __IO uint32_t K1RR;       /*!< CRYP key right register 1,                                Address offset: 0x2C */
+  __IO uint32_t K2LR;       /*!< CRYP key left  register 2,                                Address offset: 0x30 */
+  __IO uint32_t K2RR;       /*!< CRYP key right register 2,                                Address offset: 0x34 */
+  __IO uint32_t K3LR;       /*!< CRYP key left  register 3,                                Address offset: 0x38 */
+  __IO uint32_t K3RR;       /*!< CRYP key right register 3,                                Address offset: 0x3C */
+  __IO uint32_t IV0LR;      /*!< CRYP initialization vector left-word  register 0,         Address offset: 0x40 */
+  __IO uint32_t IV0RR;      /*!< CRYP initialization vector right-word register 0,         Address offset: 0x44 */
+  __IO uint32_t IV1LR;      /*!< CRYP initialization vector left-word  register 1,         Address offset: 0x48 */
+  __IO uint32_t IV1RR;      /*!< CRYP initialization vector right-word register 1,         Address offset: 0x4C */
+  __IO uint32_t CSGCMCCM0R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 0,        Address offset: 0x50 */
+  __IO uint32_t CSGCMCCM1R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 1,        Address offset: 0x54 */
+  __IO uint32_t CSGCMCCM2R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 2,        Address offset: 0x58 */
+  __IO uint32_t CSGCMCCM3R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 3,        Address offset: 0x5C */
+  __IO uint32_t CSGCMCCM4R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 4,        Address offset: 0x60 */
+  __IO uint32_t CSGCMCCM5R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 5,        Address offset: 0x64 */
+  __IO uint32_t CSGCMCCM6R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 6,        Address offset: 0x68 */
+  __IO uint32_t CSGCMCCM7R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 7,        Address offset: 0x6C */
+  __IO uint32_t CSGCM0R;    /*!< CRYP GCM/GMAC context swap register 0,                    Address offset: 0x70 */
+  __IO uint32_t CSGCM1R;    /*!< CRYP GCM/GMAC context swap register 1,                    Address offset: 0x74 */
+  __IO uint32_t CSGCM2R;    /*!< CRYP GCM/GMAC context swap register 2,                    Address offset: 0x78 */
+  __IO uint32_t CSGCM3R;    /*!< CRYP GCM/GMAC context swap register 3,                    Address offset: 0x7C */
+  __IO uint32_t CSGCM4R;    /*!< CRYP GCM/GMAC context swap register 4,                    Address offset: 0x80 */
+  __IO uint32_t CSGCM5R;    /*!< CRYP GCM/GMAC context swap register 5,                    Address offset: 0x84 */
+  __IO uint32_t CSGCM6R;    /*!< CRYP GCM/GMAC context swap register 6,                    Address offset: 0x88 */
+  __IO uint32_t CSGCM7R;    /*!< CRYP GCM/GMAC context swap register 7,                    Address offset: 0x8C */
 } CRYP_TypeDef;
 
 /** 
@@ -826,14 +826,14 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;               /*!< HASH control register,          Address offset: 0x00        */
-  __IOM uint32_t DIN;              /*!< HASH data input register,       Address offset: 0x04        */
-  __IOM uint32_t STR;              /*!< HASH start register,            Address offset: 0x08        */
-  __IOM uint32_t HR[5];            /*!< HASH digest registers,          Address offset: 0x0C-0x1C   */
-  __IOM uint32_t IMR;              /*!< HASH interrupt enable register, Address offset: 0x20        */
-  __IOM uint32_t SR;               /*!< HASH status register,           Address offset: 0x24        */
+  __IO uint32_t CR;               /*!< HASH control register,          Address offset: 0x00        */
+  __IO uint32_t DIN;              /*!< HASH data input register,       Address offset: 0x04        */
+  __IO uint32_t STR;              /*!< HASH start register,            Address offset: 0x08        */
+  __IO uint32_t HR[5];            /*!< HASH digest registers,          Address offset: 0x0C-0x1C   */
+  __IO uint32_t IMR;              /*!< HASH interrupt enable register, Address offset: 0x20        */
+  __IO uint32_t SR;               /*!< HASH status register,           Address offset: 0x24        */
        uint32_t RESERVED[52];     /*!< Reserved, 0x28-0xF4                                         */
-  __IOM uint32_t CSR[54];          /*!< HASH context swap registers,    Address offset: 0x0F8-0x1CC */
+  __IO uint32_t CSR[54];          /*!< HASH context swap registers,    Address offset: 0x0F8-0x1CC */
 } HASH_TypeDef;
 
 /** 
@@ -842,7 +842,7 @@ typedef struct
 
 typedef struct 
 {
-  __IOM uint32_t HR[5];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */ 
+  __IO uint32_t HR[5];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */ 
 } HASH_DIGEST_TypeDef;
 
 /** 
@@ -851,9 +851,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -861,24 +861,24 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved40[48];           /*!< Reserved                                0x40-0xFF */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -886,26 +886,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -913,13 +913,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -928,12 +928,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -942,13 +942,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -956,12 +956,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f423xx.h
+++ b/Include/stm32f423xx.h
@@ -190,33 +190,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -227,10 +227,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -239,10 +239,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -251,8 +251,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -261,26 +261,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -291,11 +291,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /**
@@ -303,21 +303,21 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t FLTCR1;      /*!< DFSDM control register1,                          Address offset: 0x100 */
-  __IOM uint32_t FLTCR2;      /*!< DFSDM control register2,                          Address offset: 0x104 */
-  __IOM uint32_t FLTISR;      /*!< DFSDM interrupt and status register,              Address offset: 0x108 */
-  __IOM uint32_t FLTICR;      /*!< DFSDM interrupt flag clear register,              Address offset: 0x10C */
-  __IOM uint32_t FLTJCHGR;    /*!< DFSDM injected channel group selection register,  Address offset: 0x110 */
-  __IOM uint32_t FLTFCR;      /*!< DFSDM filter control register,                    Address offset: 0x114 */
-  __IOM uint32_t FLTJDATAR;   /*!< DFSDM data register for injected group,           Address offset: 0x118 */
-  __IOM uint32_t FLTRDATAR;   /*!< DFSDM data register for regular group,            Address offset: 0x11C */
-  __IOM uint32_t FLTAWHTR;    /*!< DFSDM analog watchdog high threshold register,    Address offset: 0x120 */
-  __IOM uint32_t FLTAWLTR;    /*!< DFSDM analog watchdog low threshold register,     Address offset: 0x124 */
-  __IOM uint32_t FLTAWSR;     /*!< DFSDM analog watchdog status register             Address offset: 0x128 */
-  __IOM uint32_t FLTAWCFR;    /*!< DFSDM analog watchdog clear flag register         Address offset: 0x12C */
-  __IOM uint32_t FLTEXMAX;    /*!< DFSDM extreme detector maximum register,          Address offset: 0x130 */
-  __IOM uint32_t FLTEXMIN;    /*!< DFSDM extreme detector minimum register           Address offset: 0x134 */
-  __IOM uint32_t FLTCNVTIMR;  /*!< DFSDM conversion timer,                           Address offset: 0x138 */
+  __IO uint32_t FLTCR1;      /*!< DFSDM control register1,                          Address offset: 0x100 */
+  __IO uint32_t FLTCR2;      /*!< DFSDM control register2,                          Address offset: 0x104 */
+  __IO uint32_t FLTISR;      /*!< DFSDM interrupt and status register,              Address offset: 0x108 */
+  __IO uint32_t FLTICR;      /*!< DFSDM interrupt flag clear register,              Address offset: 0x10C */
+  __IO uint32_t FLTJCHGR;    /*!< DFSDM injected channel group selection register,  Address offset: 0x110 */
+  __IO uint32_t FLTFCR;      /*!< DFSDM filter control register,                    Address offset: 0x114 */
+  __IO uint32_t FLTJDATAR;   /*!< DFSDM data register for injected group,           Address offset: 0x118 */
+  __IO uint32_t FLTRDATAR;   /*!< DFSDM data register for regular group,            Address offset: 0x11C */
+  __IO uint32_t FLTAWHTR;    /*!< DFSDM analog watchdog high threshold register,    Address offset: 0x120 */
+  __IO uint32_t FLTAWLTR;    /*!< DFSDM analog watchdog low threshold register,     Address offset: 0x124 */
+  __IO uint32_t FLTAWSR;     /*!< DFSDM analog watchdog status register             Address offset: 0x128 */
+  __IO uint32_t FLTAWCFR;    /*!< DFSDM analog watchdog clear flag register         Address offset: 0x12C */
+  __IO uint32_t FLTEXMAX;    /*!< DFSDM extreme detector maximum register,          Address offset: 0x130 */
+  __IO uint32_t FLTEXMIN;    /*!< DFSDM extreme detector minimum register           Address offset: 0x134 */
+  __IO uint32_t FLTCNVTIMR;  /*!< DFSDM conversion timer,                           Address offset: 0x138 */
 } DFSDM_Filter_TypeDef;
 
 /**
@@ -325,12 +325,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t CHCFGR1;     /*!< DFSDM channel configuration register1,            Address offset: 0x00 */
-  __IOM uint32_t CHCFGR2;     /*!< DFSDM channel configuration register2,            Address offset: 0x04 */
-  __IOM uint32_t CHAWSCDR;    /*!< DFSDM channel analog watchdog and
+  __IO uint32_t CHCFGR1;     /*!< DFSDM channel configuration register1,            Address offset: 0x00 */
+  __IO uint32_t CHCFGR2;     /*!< DFSDM channel configuration register2,            Address offset: 0x04 */
+  __IO uint32_t CHAWSCDR;    /*!< DFSDM channel analog watchdog and
                                   short circuit detector register,                  Address offset: 0x08 */
-  __IOM uint32_t CHWDATAR;    /*!< DFSDM channel watchdog filter data register,      Address offset: 0x0C */
-  __IOM uint32_t CHDATINR;    /*!< DFSDM channel data input register,                Address offset: 0x10 */
+  __IO uint32_t CHWDATAR;    /*!< DFSDM channel watchdog filter data register,      Address offset: 0x0C */
+  __IO uint32_t CHDATINR;    /*!< DFSDM channel data input register,                Address offset: 0x10 */
 } DFSDM_Channel_TypeDef;
 
 /** 
@@ -339,20 +339,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -361,10 +361,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 
@@ -374,20 +374,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -396,12 +396,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -410,13 +410,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 
@@ -427,7 +427,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */   
 } FSMC_Bank1_TypeDef;
 
 /** 
@@ -436,7 +436,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FSMC_Bank1E_TypeDef;
 /** 
   * @brief General Purpose I/O
@@ -444,15 +444,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -461,15 +461,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED;     /*!< Reserved, 0x18                                                               */
-  __IOM uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CFGR2;        /*!< SYSCFG Configuration register2,                    Address offset: 0x1C      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
   uint32_t      RESERVED1[2]; /*!< Reserved, 0x24-0x28                                                          */
-  __IOM uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x2C      */
-  __IOM uint32_t MCHDLYCR;     /*!< SYSCFG multi-channel delay register,               Address offset: 0x30      */
+  __IO uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x2C      */
+  __IO uint32_t MCHDLYCR;     /*!< SYSCFG multi-channel delay register,               Address offset: 0x30      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -478,16 +478,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /**
@@ -496,17 +496,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
-  __IOM uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
-  __IOM uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
-  __IOM uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
-  __IOM uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
-  __IOM uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
-  __IOM uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
-  __IOM uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
-  __IOM uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
-  __IOM uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
+  __IO uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
 } FMPI2C_TypeDef;
 
 /** 
@@ -515,10 +515,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -528,8 +528,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -538,40 +538,40 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
   uint32_t      RESERVED7;     /*!< Reserved, 0x84                                                                    */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
-  __IOM uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                            Address offset: 0x90 */
-  __IOM uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                            Address offset: 0x90 */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
 } RCC_TypeDef;
 
 /** 
@@ -580,46 +580,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -628,19 +628,19 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
+  __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
 } SAI_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
-  __IOM uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
-  __IOM uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
-  __IOM uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
-  __IOM uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
-  __IOM uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
-  __IOM uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
+  __IO uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
+  __IO uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
+  __IO uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
+  __IO uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
+  __IO uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
+  __IO uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
+  __IO uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
 } SAI_Block_TypeDef;
 
 /** 
@@ -649,26 +649,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -677,15 +677,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 /** 
@@ -694,19 +694,19 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
-  __IOM uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
-  __IOM uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
-  __IOM uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
-  __IOM uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
-  __IOM uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
-  __IOM uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
-  __IOM uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
-  __IOM uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
-  __IOM uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
-  __IOM uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
-  __IOM uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
+  __IO uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
+  __IO uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
+  __IO uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
+  __IO uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
+  __IO uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
+  __IO uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
+  __IO uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
+  __IO uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
+  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
+  __IO uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
+  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
 } QUADSPI_TypeDef;
 
 /** 
@@ -715,27 +715,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -744,13 +744,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -759,9 +759,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /**
@@ -770,30 +770,30 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t CR;          /*!< AES control register,                        Address offset: 0x00 */
-  __IOM uint32_t SR;          /*!< AES status register,                         Address offset: 0x04 */
-  __IOM uint32_t DINR;        /*!< AES data input register,                     Address offset: 0x08 */
-  __IOM uint32_t DOUTR;       /*!< AES data output register,                    Address offset: 0x0C */
-  __IOM uint32_t KEYR0;       /*!< AES key register 0,                          Address offset: 0x10 */
-  __IOM uint32_t KEYR1;       /*!< AES key register 1,                          Address offset: 0x14 */
-  __IOM uint32_t KEYR2;       /*!< AES key register 2,                          Address offset: 0x18 */
-  __IOM uint32_t KEYR3;       /*!< AES key register 3,                          Address offset: 0x1C */
-  __IOM uint32_t IVR0;        /*!< AES initialization vector register 0,        Address offset: 0x20 */
-  __IOM uint32_t IVR1;        /*!< AES initialization vector register 1,        Address offset: 0x24 */
-  __IOM uint32_t IVR2;        /*!< AES initialization vector register 2,        Address offset: 0x28 */
-  __IOM uint32_t IVR3;        /*!< AES initialization vector register 3,        Address offset: 0x2C */
-  __IOM uint32_t KEYR4;       /*!< AES key register 4,                          Address offset: 0x30 */
-  __IOM uint32_t KEYR5;       /*!< AES key register 5,                          Address offset: 0x34 */
-  __IOM uint32_t KEYR6;       /*!< AES key register 6,                          Address offset: 0x38 */
-  __IOM uint32_t KEYR7;       /*!< AES key register 7,                          Address offset: 0x3C */
-  __IOM uint32_t SUSP0R;      /*!< AES Suspend register 0,                      Address offset: 0x40 */
-  __IOM uint32_t SUSP1R;      /*!< AES Suspend register 1,                      Address offset: 0x44 */
-  __IOM uint32_t SUSP2R;      /*!< AES Suspend register 2,                      Address offset: 0x48 */
-  __IOM uint32_t SUSP3R;      /*!< AES Suspend register 3,                      Address offset: 0x4C */
-  __IOM uint32_t SUSP4R;      /*!< AES Suspend register 4,                      Address offset: 0x50 */
-  __IOM uint32_t SUSP5R;      /*!< AES Suspend register 5,                      Address offset: 0x54 */
-  __IOM uint32_t SUSP6R;      /*!< AES Suspend register 6,                      Address offset: 0x58 */
-  __IOM uint32_t SUSP7R;      /*!< AES Suspend register 7,                      Address offset: 0x6C */
+  __IO uint32_t CR;          /*!< AES control register,                        Address offset: 0x00 */
+  __IO uint32_t SR;          /*!< AES status register,                         Address offset: 0x04 */
+  __IO uint32_t DINR;        /*!< AES data input register,                     Address offset: 0x08 */
+  __IO uint32_t DOUTR;       /*!< AES data output register,                    Address offset: 0x0C */
+  __IO uint32_t KEYR0;       /*!< AES key register 0,                          Address offset: 0x10 */
+  __IO uint32_t KEYR1;       /*!< AES key register 1,                          Address offset: 0x14 */
+  __IO uint32_t KEYR2;       /*!< AES key register 2,                          Address offset: 0x18 */
+  __IO uint32_t KEYR3;       /*!< AES key register 3,                          Address offset: 0x1C */
+  __IO uint32_t IVR0;        /*!< AES initialization vector register 0,        Address offset: 0x20 */
+  __IO uint32_t IVR1;        /*!< AES initialization vector register 1,        Address offset: 0x24 */
+  __IO uint32_t IVR2;        /*!< AES initialization vector register 2,        Address offset: 0x28 */
+  __IO uint32_t IVR3;        /*!< AES initialization vector register 3,        Address offset: 0x2C */
+  __IO uint32_t KEYR4;       /*!< AES key register 4,                          Address offset: 0x30 */
+  __IO uint32_t KEYR5;       /*!< AES key register 5,                          Address offset: 0x34 */
+  __IO uint32_t KEYR6;       /*!< AES key register 6,                          Address offset: 0x38 */
+  __IO uint32_t KEYR7;       /*!< AES key register 7,                          Address offset: 0x3C */
+  __IO uint32_t SUSP0R;      /*!< AES Suspend register 0,                      Address offset: 0x40 */
+  __IO uint32_t SUSP1R;      /*!< AES Suspend register 1,                      Address offset: 0x44 */
+  __IO uint32_t SUSP2R;      /*!< AES Suspend register 2,                      Address offset: 0x48 */
+  __IO uint32_t SUSP3R;      /*!< AES Suspend register 3,                      Address offset: 0x4C */
+  __IO uint32_t SUSP4R;      /*!< AES Suspend register 4,                      Address offset: 0x50 */
+  __IO uint32_t SUSP5R;      /*!< AES Suspend register 5,                      Address offset: 0x54 */
+  __IO uint32_t SUSP6R;      /*!< AES Suspend register 6,                      Address offset: 0x58 */
+  __IO uint32_t SUSP7R;      /*!< AES Suspend register 7,                      Address offset: 0x6C */
 } AES_TypeDef;
 
 
@@ -803,9 +803,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -813,30 +813,30 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved5[3];             /*!< Reserved                                040h-048h */
-  __IOM uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
+  __IO uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
   uint32_t  Reserved6;                /*!< Reserved                                     050h */
-  __IOM uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
+  __IO uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
   uint32_t  Reserved;                 /*!< Reserved                                     058h */
-  __IOM uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
+  __IO uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
   uint32_t  Reserved43[40];           /*!< Reserved                                058h-0FFh */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -844,26 +844,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -871,13 +871,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -886,12 +886,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -900,13 +900,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -914,12 +914,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 
@@ -928,15 +928,15 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
-  __IOM uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
-  __IOM uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
-  __IOM uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
-  __IOM uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
-  __IOM uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
-  __IOM uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
-  __IOM uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
-  __IOM uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
+  __IO uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
 } LPTIM_TypeDef;
 
 /**

--- a/Include/stm32f427xx.h
+++ b/Include/stm32f427xx.h
@@ -183,33 +183,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -220,10 +220,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -232,10 +232,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -244,8 +244,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -254,26 +254,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -284,11 +284,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -297,20 +297,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -319,10 +319,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 /** 
@@ -331,17 +331,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
-  __IOM uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
-  __IOM uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
-  __IOM uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
-  __IOM uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
-  __IOM uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
-  __IOM uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
-  __IOM uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
-  __IOM uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
-  __IOM uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
-  __IOM uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
+  __IO uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
+  __IO uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
+  __IO uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
+  __IO uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
+  __IO uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
+  __IO uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
+  __IO uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
+  __IO uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
+  __IO uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
+  __IO uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
+  __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
 } DCMI_TypeDef;
 
 /** 
@@ -350,20 +350,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -372,29 +372,29 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
-  __IOM uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
-  __IOM uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
-  __IOM uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
-  __IOM uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
-  __IOM uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
-  __IOM uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
-  __IOM uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
-  __IOM uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
-  __IOM uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
-  __IOM uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
-  __IOM uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
-  __IOM uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
-  __IOM uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
-  __IOM uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
-  __IOM uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
-  __IOM uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
-  __IOM uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
-  __IOM uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
-  __IOM uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
+  __IO uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
+  __IO uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
+  __IO uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
+  __IO uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
+  __IO uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
+  __IO uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
+  __IO uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
+  __IO uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
+  __IO uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
+  __IO uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
+  __IO uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
+  __IO uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
+  __IO uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
+  __IO uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
+  __IO uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
+  __IO uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
+  __IO uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
+  __IO uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
+  __IO uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
+  __IO uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
   uint32_t      RESERVED[236]; /*!< Reserved, 0x50-0x3FF */
-  __IOM uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
-  __IOM uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
+  __IO uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
+  __IO uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
 } DMA2D_TypeDef;
 
 /** 
@@ -403,73 +403,73 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MACCR;
-  __IOM uint32_t MACFFR;
-  __IOM uint32_t MACHTHR;
-  __IOM uint32_t MACHTLR;
-  __IOM uint32_t MACMIIAR;
-  __IOM uint32_t MACMIIDR;
-  __IOM uint32_t MACFCR;
-  __IOM uint32_t MACVLANTR;             /*    8 */
+  __IO uint32_t MACCR;
+  __IO uint32_t MACFFR;
+  __IO uint32_t MACHTHR;
+  __IO uint32_t MACHTLR;
+  __IO uint32_t MACMIIAR;
+  __IO uint32_t MACMIIDR;
+  __IO uint32_t MACFCR;
+  __IO uint32_t MACVLANTR;             /*    8 */
   uint32_t      RESERVED0[2];
-  __IOM uint32_t MACRWUFFR;             /*   11 */
-  __IOM uint32_t MACPMTCSR;
+  __IO uint32_t MACRWUFFR;             /*   11 */
+  __IO uint32_t MACPMTCSR;
   uint32_t      RESERVED1;
-  __IOM uint32_t MACDBGR;
-  __IOM uint32_t MACSR;                 /*   15 */
-  __IOM uint32_t MACIMR;
-  __IOM uint32_t MACA0HR;
-  __IOM uint32_t MACA0LR;
-  __IOM uint32_t MACA1HR;
-  __IOM uint32_t MACA1LR;
-  __IOM uint32_t MACA2HR;
-  __IOM uint32_t MACA2LR;
-  __IOM uint32_t MACA3HR;
-  __IOM uint32_t MACA3LR;               /*   24 */
+  __IO uint32_t MACDBGR;
+  __IO uint32_t MACSR;                 /*   15 */
+  __IO uint32_t MACIMR;
+  __IO uint32_t MACA0HR;
+  __IO uint32_t MACA0LR;
+  __IO uint32_t MACA1HR;
+  __IO uint32_t MACA1LR;
+  __IO uint32_t MACA2HR;
+  __IO uint32_t MACA2LR;
+  __IO uint32_t MACA3HR;
+  __IO uint32_t MACA3LR;               /*   24 */
   uint32_t      RESERVED2[40];
-  __IOM uint32_t MMCCR;                 /*   65 */
-  __IOM uint32_t MMCRIR;
-  __IOM uint32_t MMCTIR;
-  __IOM uint32_t MMCRIMR;
-  __IOM uint32_t MMCTIMR;               /*   69 */
+  __IO uint32_t MMCCR;                 /*   65 */
+  __IO uint32_t MMCRIR;
+  __IO uint32_t MMCTIR;
+  __IO uint32_t MMCRIMR;
+  __IO uint32_t MMCTIMR;               /*   69 */
   uint32_t      RESERVED3[14];
-  __IOM uint32_t MMCTGFSCCR;            /*   84 */
-  __IOM uint32_t MMCTGFMSCCR;
+  __IO uint32_t MMCTGFSCCR;            /*   84 */
+  __IO uint32_t MMCTGFMSCCR;
   uint32_t      RESERVED4[5];
-  __IOM uint32_t MMCTGFCR;
+  __IO uint32_t MMCTGFCR;
   uint32_t      RESERVED5[10];
-  __IOM uint32_t MMCRFCECR;
-  __IOM uint32_t MMCRFAECR;
+  __IO uint32_t MMCRFCECR;
+  __IO uint32_t MMCRFAECR;
   uint32_t      RESERVED6[10];
-  __IOM uint32_t MMCRGUFCR;
+  __IO uint32_t MMCRGUFCR;
   uint32_t      RESERVED7[334];
-  __IOM uint32_t PTPTSCR;
-  __IOM uint32_t PTPSSIR;
-  __IOM uint32_t PTPTSHR;
-  __IOM uint32_t PTPTSLR;
-  __IOM uint32_t PTPTSHUR;
-  __IOM uint32_t PTPTSLUR;
-  __IOM uint32_t PTPTSAR;
-  __IOM uint32_t PTPTTHR;
-  __IOM uint32_t PTPTTLR;
-  __IOM uint32_t RESERVED8;
-  __IOM uint32_t PTPTSSR;
+  __IO uint32_t PTPTSCR;
+  __IO uint32_t PTPSSIR;
+  __IO uint32_t PTPTSHR;
+  __IO uint32_t PTPTSLR;
+  __IO uint32_t PTPTSHUR;
+  __IO uint32_t PTPTSLUR;
+  __IO uint32_t PTPTSAR;
+  __IO uint32_t PTPTTHR;
+  __IO uint32_t PTPTTLR;
+  __IO uint32_t RESERVED8;
+  __IO uint32_t PTPTSSR;
   uint32_t      RESERVED9[565];
-  __IOM uint32_t DMABMR;
-  __IOM uint32_t DMATPDR;
-  __IOM uint32_t DMARPDR;
-  __IOM uint32_t DMARDLAR;
-  __IOM uint32_t DMATDLAR;
-  __IOM uint32_t DMASR;
-  __IOM uint32_t DMAOMR;
-  __IOM uint32_t DMAIER;
-  __IOM uint32_t DMAMFBOCR;
-  __IOM uint32_t DMARSWTR;
+  __IO uint32_t DMABMR;
+  __IO uint32_t DMATPDR;
+  __IO uint32_t DMARPDR;
+  __IO uint32_t DMARDLAR;
+  __IO uint32_t DMATDLAR;
+  __IO uint32_t DMASR;
+  __IO uint32_t DMAOMR;
+  __IO uint32_t DMAIER;
+  __IO uint32_t DMAMFBOCR;
+  __IO uint32_t DMARSWTR;
   uint32_t      RESERVED10[8];
-  __IOM uint32_t DMACHTDR;
-  __IOM uint32_t DMACHRDR;
-  __IOM uint32_t DMACHTBAR;
-  __IOM uint32_t DMACHRBAR;
+  __IO uint32_t DMACHTDR;
+  __IO uint32_t DMACHRDR;
+  __IO uint32_t DMACHTBAR;
+  __IO uint32_t DMACHRBAR;
 } ETH_TypeDef;
 
 /** 
@@ -478,12 +478,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -492,13 +492,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -507,7 +507,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
 } FMC_Bank1_TypeDef; 
 
 /** 
@@ -516,7 +516,7 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FMC_Bank1E_TypeDef;
 /** 
   * @brief Flexible Memory Controller Bank2
@@ -524,20 +524,20 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
-  __IOM uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
-  __IOM uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
-  __IOM uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
+  __IO uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
+  __IO uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
+  __IO uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
+  __IO uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
   uint32_t      RESERVED0;  /*!< Reserved, 0x70                                                            */
-  __IOM uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
+  __IO uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
   uint32_t      RESERVED1;  /*!< Reserved, 0x78                                                            */
   uint32_t      RESERVED2;  /*!< Reserved, 0x7C                                                            */
-  __IOM uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
-  __IOM uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
-  __IOM uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
-  __IOM uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
+  __IO uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
+  __IO uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
+  __IO uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
+  __IO uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
   uint32_t      RESERVED3;  /*!< Reserved, 0x90                                                            */
-  __IOM uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
+  __IO uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
 } FMC_Bank2_3_TypeDef;
 
 /** 
@@ -546,11 +546,11 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
-  __IOM uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
-  __IOM uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
-  __IOM uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
-  __IOM uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
+  __IO uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
+  __IO uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
+  __IO uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
+  __IO uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
+  __IO uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
 } FMC_Bank4_TypeDef;
 
 /** 
@@ -559,11 +559,11 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
-  __IOM uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
-  __IOM uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
-  __IOM uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
-  __IOM uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
+  __IO uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
+  __IO uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
+  __IO uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
+  __IO uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
+  __IO uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
 } FMC_Bank5_6_TypeDef;
 
 /** 
@@ -572,15 +572,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -589,11 +589,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -602,16 +602,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /** 
@@ -620,10 +620,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -633,8 +633,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -643,38 +643,38 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
-  __IOM uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
 } RCC_TypeDef;
 
 /** 
@@ -683,46 +683,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -731,19 +731,19 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
+  __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
 } SAI_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
-  __IOM uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
-  __IOM uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
-  __IOM uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
-  __IOM uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
-  __IOM uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
-  __IOM uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
+  __IO uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
+  __IO uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
+  __IO uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
+  __IO uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
+  __IO uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
+  __IO uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
+  __IO uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
 } SAI_Block_TypeDef;
 
 /** 
@@ -752,26 +752,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -780,15 +780,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -798,27 +798,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -827,13 +827,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -842,9 +842,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -853,9 +853,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -863,24 +863,24 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved40[48];           /*!< Reserved                                0x40-0xFF */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -888,26 +888,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -915,13 +915,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -930,12 +930,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -944,13 +944,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -958,12 +958,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f429xx.h
+++ b/Include/stm32f429xx.h
@@ -185,33 +185,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -222,10 +222,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -234,10 +234,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -246,8 +246,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -256,26 +256,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -286,11 +286,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -299,20 +299,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -321,10 +321,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 /** 
@@ -333,17 +333,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
-  __IOM uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
-  __IOM uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
-  __IOM uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
-  __IOM uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
-  __IOM uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
-  __IOM uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
-  __IOM uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
-  __IOM uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
-  __IOM uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
-  __IOM uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
+  __IO uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
+  __IO uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
+  __IO uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
+  __IO uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
+  __IO uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
+  __IO uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
+  __IO uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
+  __IO uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
+  __IO uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
+  __IO uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
+  __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
 } DCMI_TypeDef;
 
 /** 
@@ -352,20 +352,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -374,29 +374,29 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
-  __IOM uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
-  __IOM uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
-  __IOM uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
-  __IOM uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
-  __IOM uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
-  __IOM uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
-  __IOM uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
-  __IOM uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
-  __IOM uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
-  __IOM uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
-  __IOM uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
-  __IOM uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
-  __IOM uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
-  __IOM uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
-  __IOM uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
-  __IOM uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
-  __IOM uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
-  __IOM uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
-  __IOM uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
+  __IO uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
+  __IO uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
+  __IO uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
+  __IO uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
+  __IO uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
+  __IO uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
+  __IO uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
+  __IO uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
+  __IO uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
+  __IO uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
+  __IO uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
+  __IO uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
+  __IO uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
+  __IO uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
+  __IO uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
+  __IO uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
+  __IO uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
+  __IO uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
+  __IO uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
+  __IO uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
   uint32_t      RESERVED[236]; /*!< Reserved, 0x50-0x3FF */
-  __IOM uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
-  __IOM uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
+  __IO uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
+  __IO uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
 } DMA2D_TypeDef;
 
 /** 
@@ -405,73 +405,73 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MACCR;
-  __IOM uint32_t MACFFR;
-  __IOM uint32_t MACHTHR;
-  __IOM uint32_t MACHTLR;
-  __IOM uint32_t MACMIIAR;
-  __IOM uint32_t MACMIIDR;
-  __IOM uint32_t MACFCR;
-  __IOM uint32_t MACVLANTR;             /*    8 */
+  __IO uint32_t MACCR;
+  __IO uint32_t MACFFR;
+  __IO uint32_t MACHTHR;
+  __IO uint32_t MACHTLR;
+  __IO uint32_t MACMIIAR;
+  __IO uint32_t MACMIIDR;
+  __IO uint32_t MACFCR;
+  __IO uint32_t MACVLANTR;             /*    8 */
   uint32_t      RESERVED0[2];
-  __IOM uint32_t MACRWUFFR;             /*   11 */
-  __IOM uint32_t MACPMTCSR;
+  __IO uint32_t MACRWUFFR;             /*   11 */
+  __IO uint32_t MACPMTCSR;
   uint32_t      RESERVED1;
-  __IOM uint32_t MACDBGR;
-  __IOM uint32_t MACSR;                 /*   15 */
-  __IOM uint32_t MACIMR;
-  __IOM uint32_t MACA0HR;
-  __IOM uint32_t MACA0LR;
-  __IOM uint32_t MACA1HR;
-  __IOM uint32_t MACA1LR;
-  __IOM uint32_t MACA2HR;
-  __IOM uint32_t MACA2LR;
-  __IOM uint32_t MACA3HR;
-  __IOM uint32_t MACA3LR;               /*   24 */
+  __IO uint32_t MACDBGR;
+  __IO uint32_t MACSR;                 /*   15 */
+  __IO uint32_t MACIMR;
+  __IO uint32_t MACA0HR;
+  __IO uint32_t MACA0LR;
+  __IO uint32_t MACA1HR;
+  __IO uint32_t MACA1LR;
+  __IO uint32_t MACA2HR;
+  __IO uint32_t MACA2LR;
+  __IO uint32_t MACA3HR;
+  __IO uint32_t MACA3LR;               /*   24 */
   uint32_t      RESERVED2[40];
-  __IOM uint32_t MMCCR;                 /*   65 */
-  __IOM uint32_t MMCRIR;
-  __IOM uint32_t MMCTIR;
-  __IOM uint32_t MMCRIMR;
-  __IOM uint32_t MMCTIMR;               /*   69 */
+  __IO uint32_t MMCCR;                 /*   65 */
+  __IO uint32_t MMCRIR;
+  __IO uint32_t MMCTIR;
+  __IO uint32_t MMCRIMR;
+  __IO uint32_t MMCTIMR;               /*   69 */
   uint32_t      RESERVED3[14];
-  __IOM uint32_t MMCTGFSCCR;            /*   84 */
-  __IOM uint32_t MMCTGFMSCCR;
+  __IO uint32_t MMCTGFSCCR;            /*   84 */
+  __IO uint32_t MMCTGFMSCCR;
   uint32_t      RESERVED4[5];
-  __IOM uint32_t MMCTGFCR;
+  __IO uint32_t MMCTGFCR;
   uint32_t      RESERVED5[10];
-  __IOM uint32_t MMCRFCECR;
-  __IOM uint32_t MMCRFAECR;
+  __IO uint32_t MMCRFCECR;
+  __IO uint32_t MMCRFAECR;
   uint32_t      RESERVED6[10];
-  __IOM uint32_t MMCRGUFCR;
+  __IO uint32_t MMCRGUFCR;
   uint32_t      RESERVED7[334];
-  __IOM uint32_t PTPTSCR;
-  __IOM uint32_t PTPSSIR;
-  __IOM uint32_t PTPTSHR;
-  __IOM uint32_t PTPTSLR;
-  __IOM uint32_t PTPTSHUR;
-  __IOM uint32_t PTPTSLUR;
-  __IOM uint32_t PTPTSAR;
-  __IOM uint32_t PTPTTHR;
-  __IOM uint32_t PTPTTLR;
-  __IOM uint32_t RESERVED8;
-  __IOM uint32_t PTPTSSR;
+  __IO uint32_t PTPTSCR;
+  __IO uint32_t PTPSSIR;
+  __IO uint32_t PTPTSHR;
+  __IO uint32_t PTPTSLR;
+  __IO uint32_t PTPTSHUR;
+  __IO uint32_t PTPTSLUR;
+  __IO uint32_t PTPTSAR;
+  __IO uint32_t PTPTTHR;
+  __IO uint32_t PTPTTLR;
+  __IO uint32_t RESERVED8;
+  __IO uint32_t PTPTSSR;
   uint32_t      RESERVED9[565];
-  __IOM uint32_t DMABMR;
-  __IOM uint32_t DMATPDR;
-  __IOM uint32_t DMARPDR;
-  __IOM uint32_t DMARDLAR;
-  __IOM uint32_t DMATDLAR;
-  __IOM uint32_t DMASR;
-  __IOM uint32_t DMAOMR;
-  __IOM uint32_t DMAIER;
-  __IOM uint32_t DMAMFBOCR;
-  __IOM uint32_t DMARSWTR;
+  __IO uint32_t DMABMR;
+  __IO uint32_t DMATPDR;
+  __IO uint32_t DMARPDR;
+  __IO uint32_t DMARDLAR;
+  __IO uint32_t DMATDLAR;
+  __IO uint32_t DMASR;
+  __IO uint32_t DMAOMR;
+  __IO uint32_t DMAIER;
+  __IO uint32_t DMAMFBOCR;
+  __IO uint32_t DMARSWTR;
   uint32_t      RESERVED10[8];
-  __IOM uint32_t DMACHTDR;
-  __IOM uint32_t DMACHRDR;
-  __IOM uint32_t DMACHTBAR;
-  __IOM uint32_t DMACHRBAR;
+  __IO uint32_t DMACHTDR;
+  __IO uint32_t DMACHRDR;
+  __IO uint32_t DMACHTBAR;
+  __IO uint32_t DMACHRBAR;
 } ETH_TypeDef;
 
 /** 
@@ -480,12 +480,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -494,13 +494,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -509,7 +509,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
 } FMC_Bank1_TypeDef; 
 
 /** 
@@ -518,7 +518,7 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FMC_Bank1E_TypeDef;
 /** 
   * @brief Flexible Memory Controller Bank2
@@ -526,20 +526,20 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
-  __IOM uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
-  __IOM uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
-  __IOM uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
+  __IO uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
+  __IO uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
+  __IO uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
+  __IO uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
   uint32_t      RESERVED0;  /*!< Reserved, 0x70                                                            */
-  __IOM uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
+  __IO uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
   uint32_t      RESERVED1;  /*!< Reserved, 0x78                                                            */
   uint32_t      RESERVED2;  /*!< Reserved, 0x7C                                                            */
-  __IOM uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
-  __IOM uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
-  __IOM uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
-  __IOM uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
+  __IO uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
+  __IO uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
+  __IO uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
+  __IO uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
   uint32_t      RESERVED3;  /*!< Reserved, 0x90                                                            */
-  __IOM uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
+  __IO uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
 } FMC_Bank2_3_TypeDef;
 
 /** 
@@ -548,11 +548,11 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
-  __IOM uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
-  __IOM uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
-  __IOM uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
-  __IOM uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
+  __IO uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
+  __IO uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
+  __IO uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
+  __IO uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
+  __IO uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
 } FMC_Bank4_TypeDef;
 
 /** 
@@ -561,11 +561,11 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
-  __IOM uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
-  __IOM uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
-  __IOM uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
-  __IOM uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
+  __IO uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
+  __IO uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
+  __IO uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
+  __IO uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
+  __IO uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
 } FMC_Bank5_6_TypeDef;
 
 /** 
@@ -574,15 +574,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -591,11 +591,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -604,16 +604,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /** 
@@ -622,10 +622,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 /** 
@@ -635,22 +635,22 @@ typedef struct
 typedef struct
 {
   uint32_t      RESERVED0[2];  /*!< Reserved, 0x00-0x04                                                       */
-  __IOM uint32_t SSCR;          /*!< LTDC Synchronization Size Configuration Register,    Address offset: 0x08 */
-  __IOM uint32_t BPCR;          /*!< LTDC Back Porch Configuration Register,              Address offset: 0x0C */
-  __IOM uint32_t AWCR;          /*!< LTDC Active Width Configuration Register,            Address offset: 0x10 */
-  __IOM uint32_t TWCR;          /*!< LTDC Total Width Configuration Register,             Address offset: 0x14 */
-  __IOM uint32_t GCR;           /*!< LTDC Global Control Register,                        Address offset: 0x18 */
+  __IO uint32_t SSCR;          /*!< LTDC Synchronization Size Configuration Register,    Address offset: 0x08 */
+  __IO uint32_t BPCR;          /*!< LTDC Back Porch Configuration Register,              Address offset: 0x0C */
+  __IO uint32_t AWCR;          /*!< LTDC Active Width Configuration Register,            Address offset: 0x10 */
+  __IO uint32_t TWCR;          /*!< LTDC Total Width Configuration Register,             Address offset: 0x14 */
+  __IO uint32_t GCR;           /*!< LTDC Global Control Register,                        Address offset: 0x18 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x1C-0x20                                                       */
-  __IOM uint32_t SRCR;          /*!< LTDC Shadow Reload Configuration Register,           Address offset: 0x24 */
+  __IO uint32_t SRCR;          /*!< LTDC Shadow Reload Configuration Register,           Address offset: 0x24 */
   uint32_t      RESERVED2[1];  /*!< Reserved, 0x28                                                            */
-  __IOM uint32_t BCCR;          /*!< LTDC Background Color Configuration Register,        Address offset: 0x2C */
+  __IO uint32_t BCCR;          /*!< LTDC Background Color Configuration Register,        Address offset: 0x2C */
   uint32_t      RESERVED3[1];  /*!< Reserved, 0x30                                                            */
-  __IOM uint32_t IER;           /*!< LTDC Interrupt Enable Register,                      Address offset: 0x34 */
-  __IOM uint32_t ISR;           /*!< LTDC Interrupt Status Register,                      Address offset: 0x38 */
-  __IOM uint32_t ICR;           /*!< LTDC Interrupt Clear Register,                       Address offset: 0x3C */
-  __IOM uint32_t LIPCR;         /*!< LTDC Line Interrupt Position Configuration Register, Address offset: 0x40 */
-  __IOM uint32_t CPSR;          /*!< LTDC Current Position Status Register,               Address offset: 0x44 */
-  __IOM uint32_t CDSR;          /*!< LTDC Current Display Status Register,                Address offset: 0x48 */
+  __IO uint32_t IER;           /*!< LTDC Interrupt Enable Register,                      Address offset: 0x34 */
+  __IO uint32_t ISR;           /*!< LTDC Interrupt Status Register,                      Address offset: 0x38 */
+  __IO uint32_t ICR;           /*!< LTDC Interrupt Clear Register,                       Address offset: 0x3C */
+  __IO uint32_t LIPCR;         /*!< LTDC Line Interrupt Position Configuration Register, Address offset: 0x40 */
+  __IO uint32_t CPSR;          /*!< LTDC Current Position Status Register,               Address offset: 0x44 */
+  __IO uint32_t CDSR;          /*!< LTDC Current Display Status Register,                Address offset: 0x48 */
 } LTDC_TypeDef;
 
 /** 
@@ -659,20 +659,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< LTDC Layerx Control Register                                  Address offset: 0x84 */
-  __IOM uint32_t WHPCR;         /*!< LTDC Layerx Window Horizontal Position Configuration Register Address offset: 0x88 */
-  __IOM uint32_t WVPCR;         /*!< LTDC Layerx Window Vertical Position Configuration Register   Address offset: 0x8C */
-  __IOM uint32_t CKCR;          /*!< LTDC Layerx Color Keying Configuration Register               Address offset: 0x90 */
-  __IOM uint32_t PFCR;          /*!< LTDC Layerx Pixel Format Configuration Register               Address offset: 0x94 */
-  __IOM uint32_t CACR;          /*!< LTDC Layerx Constant Alpha Configuration Register             Address offset: 0x98 */
-  __IOM uint32_t DCCR;          /*!< LTDC Layerx Default Color Configuration Register              Address offset: 0x9C */
-  __IOM uint32_t BFCR;          /*!< LTDC Layerx Blending Factors Configuration Register           Address offset: 0xA0 */
+  __IO uint32_t CR;            /*!< LTDC Layerx Control Register                                  Address offset: 0x84 */
+  __IO uint32_t WHPCR;         /*!< LTDC Layerx Window Horizontal Position Configuration Register Address offset: 0x88 */
+  __IO uint32_t WVPCR;         /*!< LTDC Layerx Window Vertical Position Configuration Register   Address offset: 0x8C */
+  __IO uint32_t CKCR;          /*!< LTDC Layerx Color Keying Configuration Register               Address offset: 0x90 */
+  __IO uint32_t PFCR;          /*!< LTDC Layerx Pixel Format Configuration Register               Address offset: 0x94 */
+  __IO uint32_t CACR;          /*!< LTDC Layerx Constant Alpha Configuration Register             Address offset: 0x98 */
+  __IO uint32_t DCCR;          /*!< LTDC Layerx Default Color Configuration Register              Address offset: 0x9C */
+  __IO uint32_t BFCR;          /*!< LTDC Layerx Blending Factors Configuration Register           Address offset: 0xA0 */
   uint32_t      RESERVED0[2];  /*!< Reserved                                                                           */
-  __IOM uint32_t CFBAR;         /*!< LTDC Layerx Color Frame Buffer Address Register               Address offset: 0xAC */
-  __IOM uint32_t CFBLR;         /*!< LTDC Layerx Color Frame Buffer Length Register                Address offset: 0xB0 */
-  __IOM uint32_t CFBLNR;        /*!< LTDC Layerx ColorFrame Buffer Line Number Register            Address offset: 0xB4 */
+  __IO uint32_t CFBAR;         /*!< LTDC Layerx Color Frame Buffer Address Register               Address offset: 0xAC */
+  __IO uint32_t CFBLR;         /*!< LTDC Layerx Color Frame Buffer Length Register                Address offset: 0xB0 */
+  __IO uint32_t CFBLNR;        /*!< LTDC Layerx ColorFrame Buffer Line Number Register            Address offset: 0xB4 */
   uint32_t      RESERVED1[3];  /*!< Reserved                                                                           */
-  __IOM uint32_t CLUTWR;        /*!< LTDC Layerx CLUT Write Register                               Address offset: 0x144*/
+  __IO uint32_t CLUTWR;        /*!< LTDC Layerx CLUT Write Register                               Address offset: 0x144*/
 } LTDC_Layer_TypeDef;
 
 /** 
@@ -681,8 +681,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -691,38 +691,38 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
-  __IOM uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
 } RCC_TypeDef;
 
 /** 
@@ -731,46 +731,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -779,19 +779,19 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
+  __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
 } SAI_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
-  __IOM uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
-  __IOM uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
-  __IOM uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
-  __IOM uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
-  __IOM uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
-  __IOM uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
+  __IO uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
+  __IO uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
+  __IO uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
+  __IO uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
+  __IO uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
+  __IO uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
+  __IO uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
 } SAI_Block_TypeDef;
 
 /** 
@@ -800,26 +800,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -828,15 +828,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -846,27 +846,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -875,13 +875,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -890,9 +890,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -901,9 +901,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -911,24 +911,24 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved40[48];           /*!< Reserved                                0x40-0xFF */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -936,26 +936,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -963,13 +963,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -978,12 +978,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -992,13 +992,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -1006,12 +1006,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f437xx.h
+++ b/Include/stm32f437xx.h
@@ -184,33 +184,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -221,10 +221,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -233,10 +233,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -245,8 +245,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -255,26 +255,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -285,11 +285,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -298,20 +298,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -320,10 +320,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 /** 
@@ -332,17 +332,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
-  __IOM uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
-  __IOM uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
-  __IOM uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
-  __IOM uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
-  __IOM uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
-  __IOM uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
-  __IOM uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
-  __IOM uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
-  __IOM uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
-  __IOM uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
+  __IO uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
+  __IO uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
+  __IO uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
+  __IO uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
+  __IO uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
+  __IO uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
+  __IO uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
+  __IO uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
+  __IO uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
+  __IO uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
+  __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
 } DCMI_TypeDef;
 
 /** 
@@ -351,20 +351,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -373,29 +373,29 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
-  __IOM uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
-  __IOM uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
-  __IOM uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
-  __IOM uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
-  __IOM uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
-  __IOM uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
-  __IOM uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
-  __IOM uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
-  __IOM uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
-  __IOM uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
-  __IOM uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
-  __IOM uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
-  __IOM uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
-  __IOM uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
-  __IOM uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
-  __IOM uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
-  __IOM uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
-  __IOM uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
-  __IOM uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
+  __IO uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
+  __IO uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
+  __IO uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
+  __IO uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
+  __IO uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
+  __IO uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
+  __IO uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
+  __IO uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
+  __IO uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
+  __IO uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
+  __IO uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
+  __IO uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
+  __IO uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
+  __IO uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
+  __IO uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
+  __IO uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
+  __IO uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
+  __IO uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
+  __IO uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
+  __IO uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
   uint32_t      RESERVED[236]; /*!< Reserved, 0x50-0x3FF */
-  __IOM uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
-  __IOM uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
+  __IO uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
+  __IO uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
 } DMA2D_TypeDef;
 
 /** 
@@ -404,73 +404,73 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MACCR;
-  __IOM uint32_t MACFFR;
-  __IOM uint32_t MACHTHR;
-  __IOM uint32_t MACHTLR;
-  __IOM uint32_t MACMIIAR;
-  __IOM uint32_t MACMIIDR;
-  __IOM uint32_t MACFCR;
-  __IOM uint32_t MACVLANTR;             /*    8 */
+  __IO uint32_t MACCR;
+  __IO uint32_t MACFFR;
+  __IO uint32_t MACHTHR;
+  __IO uint32_t MACHTLR;
+  __IO uint32_t MACMIIAR;
+  __IO uint32_t MACMIIDR;
+  __IO uint32_t MACFCR;
+  __IO uint32_t MACVLANTR;             /*    8 */
   uint32_t      RESERVED0[2];
-  __IOM uint32_t MACRWUFFR;             /*   11 */
-  __IOM uint32_t MACPMTCSR;
+  __IO uint32_t MACRWUFFR;             /*   11 */
+  __IO uint32_t MACPMTCSR;
   uint32_t      RESERVED1;
-  __IOM uint32_t MACDBGR;
-  __IOM uint32_t MACSR;                 /*   15 */
-  __IOM uint32_t MACIMR;
-  __IOM uint32_t MACA0HR;
-  __IOM uint32_t MACA0LR;
-  __IOM uint32_t MACA1HR;
-  __IOM uint32_t MACA1LR;
-  __IOM uint32_t MACA2HR;
-  __IOM uint32_t MACA2LR;
-  __IOM uint32_t MACA3HR;
-  __IOM uint32_t MACA3LR;               /*   24 */
+  __IO uint32_t MACDBGR;
+  __IO uint32_t MACSR;                 /*   15 */
+  __IO uint32_t MACIMR;
+  __IO uint32_t MACA0HR;
+  __IO uint32_t MACA0LR;
+  __IO uint32_t MACA1HR;
+  __IO uint32_t MACA1LR;
+  __IO uint32_t MACA2HR;
+  __IO uint32_t MACA2LR;
+  __IO uint32_t MACA3HR;
+  __IO uint32_t MACA3LR;               /*   24 */
   uint32_t      RESERVED2[40];
-  __IOM uint32_t MMCCR;                 /*   65 */
-  __IOM uint32_t MMCRIR;
-  __IOM uint32_t MMCTIR;
-  __IOM uint32_t MMCRIMR;
-  __IOM uint32_t MMCTIMR;               /*   69 */
+  __IO uint32_t MMCCR;                 /*   65 */
+  __IO uint32_t MMCRIR;
+  __IO uint32_t MMCTIR;
+  __IO uint32_t MMCRIMR;
+  __IO uint32_t MMCTIMR;               /*   69 */
   uint32_t      RESERVED3[14];
-  __IOM uint32_t MMCTGFSCCR;            /*   84 */
-  __IOM uint32_t MMCTGFMSCCR;
+  __IO uint32_t MMCTGFSCCR;            /*   84 */
+  __IO uint32_t MMCTGFMSCCR;
   uint32_t      RESERVED4[5];
-  __IOM uint32_t MMCTGFCR;
+  __IO uint32_t MMCTGFCR;
   uint32_t      RESERVED5[10];
-  __IOM uint32_t MMCRFCECR;
-  __IOM uint32_t MMCRFAECR;
+  __IO uint32_t MMCRFCECR;
+  __IO uint32_t MMCRFAECR;
   uint32_t      RESERVED6[10];
-  __IOM uint32_t MMCRGUFCR;
+  __IO uint32_t MMCRGUFCR;
   uint32_t      RESERVED7[334];
-  __IOM uint32_t PTPTSCR;
-  __IOM uint32_t PTPSSIR;
-  __IOM uint32_t PTPTSHR;
-  __IOM uint32_t PTPTSLR;
-  __IOM uint32_t PTPTSHUR;
-  __IOM uint32_t PTPTSLUR;
-  __IOM uint32_t PTPTSAR;
-  __IOM uint32_t PTPTTHR;
-  __IOM uint32_t PTPTTLR;
-  __IOM uint32_t RESERVED8;
-  __IOM uint32_t PTPTSSR;
+  __IO uint32_t PTPTSCR;
+  __IO uint32_t PTPSSIR;
+  __IO uint32_t PTPTSHR;
+  __IO uint32_t PTPTSLR;
+  __IO uint32_t PTPTSHUR;
+  __IO uint32_t PTPTSLUR;
+  __IO uint32_t PTPTSAR;
+  __IO uint32_t PTPTTHR;
+  __IO uint32_t PTPTTLR;
+  __IO uint32_t RESERVED8;
+  __IO uint32_t PTPTSSR;
   uint32_t      RESERVED9[565];
-  __IOM uint32_t DMABMR;
-  __IOM uint32_t DMATPDR;
-  __IOM uint32_t DMARPDR;
-  __IOM uint32_t DMARDLAR;
-  __IOM uint32_t DMATDLAR;
-  __IOM uint32_t DMASR;
-  __IOM uint32_t DMAOMR;
-  __IOM uint32_t DMAIER;
-  __IOM uint32_t DMAMFBOCR;
-  __IOM uint32_t DMARSWTR;
+  __IO uint32_t DMABMR;
+  __IO uint32_t DMATPDR;
+  __IO uint32_t DMARPDR;
+  __IO uint32_t DMARDLAR;
+  __IO uint32_t DMATDLAR;
+  __IO uint32_t DMASR;
+  __IO uint32_t DMAOMR;
+  __IO uint32_t DMAIER;
+  __IO uint32_t DMAMFBOCR;
+  __IO uint32_t DMARSWTR;
   uint32_t      RESERVED10[8];
-  __IOM uint32_t DMACHTDR;
-  __IOM uint32_t DMACHRDR;
-  __IOM uint32_t DMACHTBAR;
-  __IOM uint32_t DMACHRBAR;
+  __IO uint32_t DMACHTDR;
+  __IO uint32_t DMACHRDR;
+  __IO uint32_t DMACHTBAR;
+  __IO uint32_t DMACHRBAR;
 } ETH_TypeDef;
 
 /** 
@@ -479,12 +479,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -493,13 +493,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -508,7 +508,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
 } FMC_Bank1_TypeDef; 
 
 /** 
@@ -517,7 +517,7 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FMC_Bank1E_TypeDef;
 /** 
   * @brief Flexible Memory Controller Bank2
@@ -525,20 +525,20 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
-  __IOM uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
-  __IOM uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
-  __IOM uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
+  __IO uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
+  __IO uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
+  __IO uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
+  __IO uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
   uint32_t      RESERVED0;  /*!< Reserved, 0x70                                                            */
-  __IOM uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
+  __IO uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
   uint32_t      RESERVED1;  /*!< Reserved, 0x78                                                            */
   uint32_t      RESERVED2;  /*!< Reserved, 0x7C                                                            */
-  __IOM uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
-  __IOM uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
-  __IOM uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
-  __IOM uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
+  __IO uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
+  __IO uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
+  __IO uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
+  __IO uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
   uint32_t      RESERVED3;  /*!< Reserved, 0x90                                                            */
-  __IOM uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
+  __IO uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
 } FMC_Bank2_3_TypeDef;
 
 /** 
@@ -547,11 +547,11 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
-  __IOM uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
-  __IOM uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
-  __IOM uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
-  __IOM uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
+  __IO uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
+  __IO uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
+  __IO uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
+  __IO uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
+  __IO uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
 } FMC_Bank4_TypeDef;
 
 /** 
@@ -560,11 +560,11 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
-  __IOM uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
-  __IOM uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
-  __IOM uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
-  __IOM uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
+  __IO uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
+  __IO uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
+  __IO uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
+  __IO uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
+  __IO uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
 } FMC_Bank5_6_TypeDef;
 
 /** 
@@ -573,15 +573,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -590,11 +590,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -603,16 +603,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /** 
@@ -621,10 +621,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -634,8 +634,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -644,38 +644,38 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
-  __IOM uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
 } RCC_TypeDef;
 
 /** 
@@ -684,46 +684,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -732,19 +732,19 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
+  __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
 } SAI_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
-  __IOM uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
-  __IOM uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
-  __IOM uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
-  __IOM uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
-  __IOM uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
-  __IOM uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
+  __IO uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
+  __IO uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
+  __IO uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
+  __IO uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
+  __IO uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
+  __IO uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
+  __IO uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
 } SAI_Block_TypeDef;
 
 /** 
@@ -753,26 +753,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -781,15 +781,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -799,27 +799,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -828,13 +828,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -843,9 +843,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -854,42 +854,42 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;         /*!< CRYP control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SR;         /*!< CRYP status register,                                     Address offset: 0x04 */
-  __IOM uint32_t DIN;         /*!< CRYP data input register,                                 Address offset: 0x08 */
-  __IOM uint32_t DOUT;       /*!< CRYP data output register,                                Address offset: 0x0C */
-  __IOM uint32_t DMACR;      /*!< CRYP DMA control register,                                Address offset: 0x10 */
-  __IOM uint32_t IMSCR;      /*!< CRYP interrupt mask set/clear register,                   Address offset: 0x14 */
-  __IOM uint32_t RISR;       /*!< CRYP raw interrupt status register,                       Address offset: 0x18 */
-  __IOM uint32_t MISR;       /*!< CRYP masked interrupt status register,                    Address offset: 0x1C */
-  __IOM uint32_t K0LR;       /*!< CRYP key left  register 0,                                Address offset: 0x20 */
-  __IOM uint32_t K0RR;       /*!< CRYP key right register 0,                                Address offset: 0x24 */
-  __IOM uint32_t K1LR;       /*!< CRYP key left  register 1,                                Address offset: 0x28 */
-  __IOM uint32_t K1RR;       /*!< CRYP key right register 1,                                Address offset: 0x2C */
-  __IOM uint32_t K2LR;       /*!< CRYP key left  register 2,                                Address offset: 0x30 */
-  __IOM uint32_t K2RR;       /*!< CRYP key right register 2,                                Address offset: 0x34 */
-  __IOM uint32_t K3LR;       /*!< CRYP key left  register 3,                                Address offset: 0x38 */
-  __IOM uint32_t K3RR;       /*!< CRYP key right register 3,                                Address offset: 0x3C */
-  __IOM uint32_t IV0LR;      /*!< CRYP initialization vector left-word  register 0,         Address offset: 0x40 */
-  __IOM uint32_t IV0RR;      /*!< CRYP initialization vector right-word register 0,         Address offset: 0x44 */
-  __IOM uint32_t IV1LR;      /*!< CRYP initialization vector left-word  register 1,         Address offset: 0x48 */
-  __IOM uint32_t IV1RR;      /*!< CRYP initialization vector right-word register 1,         Address offset: 0x4C */
-  __IOM uint32_t CSGCMCCM0R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 0,        Address offset: 0x50 */
-  __IOM uint32_t CSGCMCCM1R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 1,        Address offset: 0x54 */
-  __IOM uint32_t CSGCMCCM2R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 2,        Address offset: 0x58 */
-  __IOM uint32_t CSGCMCCM3R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 3,        Address offset: 0x5C */
-  __IOM uint32_t CSGCMCCM4R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 4,        Address offset: 0x60 */
-  __IOM uint32_t CSGCMCCM5R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 5,        Address offset: 0x64 */
-  __IOM uint32_t CSGCMCCM6R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 6,        Address offset: 0x68 */
-  __IOM uint32_t CSGCMCCM7R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 7,        Address offset: 0x6C */
-  __IOM uint32_t CSGCM0R;    /*!< CRYP GCM/GMAC context swap register 0,                    Address offset: 0x70 */
-  __IOM uint32_t CSGCM1R;    /*!< CRYP GCM/GMAC context swap register 1,                    Address offset: 0x74 */
-  __IOM uint32_t CSGCM2R;    /*!< CRYP GCM/GMAC context swap register 2,                    Address offset: 0x78 */
-  __IOM uint32_t CSGCM3R;    /*!< CRYP GCM/GMAC context swap register 3,                    Address offset: 0x7C */
-  __IOM uint32_t CSGCM4R;    /*!< CRYP GCM/GMAC context swap register 4,                    Address offset: 0x80 */
-  __IOM uint32_t CSGCM5R;    /*!< CRYP GCM/GMAC context swap register 5,                    Address offset: 0x84 */
-  __IOM uint32_t CSGCM6R;    /*!< CRYP GCM/GMAC context swap register 6,                    Address offset: 0x88 */
-  __IOM uint32_t CSGCM7R;    /*!< CRYP GCM/GMAC context swap register 7,                    Address offset: 0x8C */
+  __IO uint32_t CR;         /*!< CRYP control register,                                    Address offset: 0x00 */
+  __IO uint32_t SR;         /*!< CRYP status register,                                     Address offset: 0x04 */
+  __IO uint32_t DIN;         /*!< CRYP data input register,                                 Address offset: 0x08 */
+  __IO uint32_t DOUT;       /*!< CRYP data output register,                                Address offset: 0x0C */
+  __IO uint32_t DMACR;      /*!< CRYP DMA control register,                                Address offset: 0x10 */
+  __IO uint32_t IMSCR;      /*!< CRYP interrupt mask set/clear register,                   Address offset: 0x14 */
+  __IO uint32_t RISR;       /*!< CRYP raw interrupt status register,                       Address offset: 0x18 */
+  __IO uint32_t MISR;       /*!< CRYP masked interrupt status register,                    Address offset: 0x1C */
+  __IO uint32_t K0LR;       /*!< CRYP key left  register 0,                                Address offset: 0x20 */
+  __IO uint32_t K0RR;       /*!< CRYP key right register 0,                                Address offset: 0x24 */
+  __IO uint32_t K1LR;       /*!< CRYP key left  register 1,                                Address offset: 0x28 */
+  __IO uint32_t K1RR;       /*!< CRYP key right register 1,                                Address offset: 0x2C */
+  __IO uint32_t K2LR;       /*!< CRYP key left  register 2,                                Address offset: 0x30 */
+  __IO uint32_t K2RR;       /*!< CRYP key right register 2,                                Address offset: 0x34 */
+  __IO uint32_t K3LR;       /*!< CRYP key left  register 3,                                Address offset: 0x38 */
+  __IO uint32_t K3RR;       /*!< CRYP key right register 3,                                Address offset: 0x3C */
+  __IO uint32_t IV0LR;      /*!< CRYP initialization vector left-word  register 0,         Address offset: 0x40 */
+  __IO uint32_t IV0RR;      /*!< CRYP initialization vector right-word register 0,         Address offset: 0x44 */
+  __IO uint32_t IV1LR;      /*!< CRYP initialization vector left-word  register 1,         Address offset: 0x48 */
+  __IO uint32_t IV1RR;      /*!< CRYP initialization vector right-word register 1,         Address offset: 0x4C */
+  __IO uint32_t CSGCMCCM0R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 0,        Address offset: 0x50 */
+  __IO uint32_t CSGCMCCM1R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 1,        Address offset: 0x54 */
+  __IO uint32_t CSGCMCCM2R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 2,        Address offset: 0x58 */
+  __IO uint32_t CSGCMCCM3R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 3,        Address offset: 0x5C */
+  __IO uint32_t CSGCMCCM4R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 4,        Address offset: 0x60 */
+  __IO uint32_t CSGCMCCM5R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 5,        Address offset: 0x64 */
+  __IO uint32_t CSGCMCCM6R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 6,        Address offset: 0x68 */
+  __IO uint32_t CSGCMCCM7R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 7,        Address offset: 0x6C */
+  __IO uint32_t CSGCM0R;    /*!< CRYP GCM/GMAC context swap register 0,                    Address offset: 0x70 */
+  __IO uint32_t CSGCM1R;    /*!< CRYP GCM/GMAC context swap register 1,                    Address offset: 0x74 */
+  __IO uint32_t CSGCM2R;    /*!< CRYP GCM/GMAC context swap register 2,                    Address offset: 0x78 */
+  __IO uint32_t CSGCM3R;    /*!< CRYP GCM/GMAC context swap register 3,                    Address offset: 0x7C */
+  __IO uint32_t CSGCM4R;    /*!< CRYP GCM/GMAC context swap register 4,                    Address offset: 0x80 */
+  __IO uint32_t CSGCM5R;    /*!< CRYP GCM/GMAC context swap register 5,                    Address offset: 0x84 */
+  __IO uint32_t CSGCM6R;    /*!< CRYP GCM/GMAC context swap register 6,                    Address offset: 0x88 */
+  __IO uint32_t CSGCM7R;    /*!< CRYP GCM/GMAC context swap register 7,                    Address offset: 0x8C */
 } CRYP_TypeDef;
 
 /** 
@@ -898,14 +898,14 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;               /*!< HASH control register,          Address offset: 0x00        */
-  __IOM uint32_t DIN;              /*!< HASH data input register,       Address offset: 0x04        */
-  __IOM uint32_t STR;              /*!< HASH start register,            Address offset: 0x08        */
-  __IOM uint32_t HR[5];            /*!< HASH digest registers,          Address offset: 0x0C-0x1C   */
-  __IOM uint32_t IMR;              /*!< HASH interrupt enable register, Address offset: 0x20        */
-  __IOM uint32_t SR;               /*!< HASH status register,           Address offset: 0x24        */
+  __IO uint32_t CR;               /*!< HASH control register,          Address offset: 0x00        */
+  __IO uint32_t DIN;              /*!< HASH data input register,       Address offset: 0x04        */
+  __IO uint32_t STR;              /*!< HASH start register,            Address offset: 0x08        */
+  __IO uint32_t HR[5];            /*!< HASH digest registers,          Address offset: 0x0C-0x1C   */
+  __IO uint32_t IMR;              /*!< HASH interrupt enable register, Address offset: 0x20        */
+  __IO uint32_t SR;               /*!< HASH status register,           Address offset: 0x24        */
        uint32_t RESERVED[52];     /*!< Reserved, 0x28-0xF4                                         */
-  __IOM uint32_t CSR[54];          /*!< HASH context swap registers,    Address offset: 0x0F8-0x1CC */
+  __IO uint32_t CSR[54];          /*!< HASH context swap registers,    Address offset: 0x0F8-0x1CC */
 } HASH_TypeDef;
 
 /** 
@@ -914,7 +914,7 @@ typedef struct
 
 typedef struct 
 {
-  __IOM uint32_t HR[8];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */ 
+  __IO uint32_t HR[8];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */ 
 } HASH_DIGEST_TypeDef;
 
 /** 
@@ -923,9 +923,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -933,24 +933,24 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved40[48];           /*!< Reserved                                0x40-0xFF */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -958,26 +958,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -985,13 +985,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -1000,12 +1000,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -1014,13 +1014,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -1028,12 +1028,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f439xx.h
+++ b/Include/stm32f439xx.h
@@ -186,33 +186,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -223,10 +223,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -235,10 +235,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -247,8 +247,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -257,26 +257,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -287,11 +287,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -300,20 +300,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -322,10 +322,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 /** 
@@ -334,17 +334,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
-  __IOM uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
-  __IOM uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
-  __IOM uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
-  __IOM uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
-  __IOM uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
-  __IOM uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
-  __IOM uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
-  __IOM uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
-  __IOM uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
-  __IOM uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
+  __IO uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
+  __IO uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
+  __IO uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
+  __IO uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
+  __IO uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
+  __IO uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
+  __IO uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
+  __IO uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
+  __IO uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
+  __IO uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
+  __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
 } DCMI_TypeDef;
 
 /** 
@@ -353,20 +353,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -375,29 +375,29 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
-  __IOM uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
-  __IOM uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
-  __IOM uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
-  __IOM uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
-  __IOM uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
-  __IOM uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
-  __IOM uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
-  __IOM uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
-  __IOM uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
-  __IOM uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
-  __IOM uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
-  __IOM uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
-  __IOM uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
-  __IOM uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
-  __IOM uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
-  __IOM uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
-  __IOM uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
-  __IOM uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
-  __IOM uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
+  __IO uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
+  __IO uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
+  __IO uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
+  __IO uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
+  __IO uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
+  __IO uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
+  __IO uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
+  __IO uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
+  __IO uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
+  __IO uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
+  __IO uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
+  __IO uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
+  __IO uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
+  __IO uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
+  __IO uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
+  __IO uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
+  __IO uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
+  __IO uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
+  __IO uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
+  __IO uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
   uint32_t      RESERVED[236]; /*!< Reserved, 0x50-0x3FF */
-  __IOM uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
-  __IOM uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
+  __IO uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
+  __IO uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
 } DMA2D_TypeDef;
 
 /** 
@@ -406,73 +406,73 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MACCR;
-  __IOM uint32_t MACFFR;
-  __IOM uint32_t MACHTHR;
-  __IOM uint32_t MACHTLR;
-  __IOM uint32_t MACMIIAR;
-  __IOM uint32_t MACMIIDR;
-  __IOM uint32_t MACFCR;
-  __IOM uint32_t MACVLANTR;             /*    8 */
+  __IO uint32_t MACCR;
+  __IO uint32_t MACFFR;
+  __IO uint32_t MACHTHR;
+  __IO uint32_t MACHTLR;
+  __IO uint32_t MACMIIAR;
+  __IO uint32_t MACMIIDR;
+  __IO uint32_t MACFCR;
+  __IO uint32_t MACVLANTR;             /*    8 */
   uint32_t      RESERVED0[2];
-  __IOM uint32_t MACRWUFFR;             /*   11 */
-  __IOM uint32_t MACPMTCSR;
+  __IO uint32_t MACRWUFFR;             /*   11 */
+  __IO uint32_t MACPMTCSR;
   uint32_t      RESERVED1;
-  __IOM uint32_t MACDBGR;
-  __IOM uint32_t MACSR;                 /*   15 */
-  __IOM uint32_t MACIMR;
-  __IOM uint32_t MACA0HR;
-  __IOM uint32_t MACA0LR;
-  __IOM uint32_t MACA1HR;
-  __IOM uint32_t MACA1LR;
-  __IOM uint32_t MACA2HR;
-  __IOM uint32_t MACA2LR;
-  __IOM uint32_t MACA3HR;
-  __IOM uint32_t MACA3LR;               /*   24 */
+  __IO uint32_t MACDBGR;
+  __IO uint32_t MACSR;                 /*   15 */
+  __IO uint32_t MACIMR;
+  __IO uint32_t MACA0HR;
+  __IO uint32_t MACA0LR;
+  __IO uint32_t MACA1HR;
+  __IO uint32_t MACA1LR;
+  __IO uint32_t MACA2HR;
+  __IO uint32_t MACA2LR;
+  __IO uint32_t MACA3HR;
+  __IO uint32_t MACA3LR;               /*   24 */
   uint32_t      RESERVED2[40];
-  __IOM uint32_t MMCCR;                 /*   65 */
-  __IOM uint32_t MMCRIR;
-  __IOM uint32_t MMCTIR;
-  __IOM uint32_t MMCRIMR;
-  __IOM uint32_t MMCTIMR;               /*   69 */
+  __IO uint32_t MMCCR;                 /*   65 */
+  __IO uint32_t MMCRIR;
+  __IO uint32_t MMCTIR;
+  __IO uint32_t MMCRIMR;
+  __IO uint32_t MMCTIMR;               /*   69 */
   uint32_t      RESERVED3[14];
-  __IOM uint32_t MMCTGFSCCR;            /*   84 */
-  __IOM uint32_t MMCTGFMSCCR;
+  __IO uint32_t MMCTGFSCCR;            /*   84 */
+  __IO uint32_t MMCTGFMSCCR;
   uint32_t      RESERVED4[5];
-  __IOM uint32_t MMCTGFCR;
+  __IO uint32_t MMCTGFCR;
   uint32_t      RESERVED5[10];
-  __IOM uint32_t MMCRFCECR;
-  __IOM uint32_t MMCRFAECR;
+  __IO uint32_t MMCRFCECR;
+  __IO uint32_t MMCRFAECR;
   uint32_t      RESERVED6[10];
-  __IOM uint32_t MMCRGUFCR;
+  __IO uint32_t MMCRGUFCR;
   uint32_t      RESERVED7[334];
-  __IOM uint32_t PTPTSCR;
-  __IOM uint32_t PTPSSIR;
-  __IOM uint32_t PTPTSHR;
-  __IOM uint32_t PTPTSLR;
-  __IOM uint32_t PTPTSHUR;
-  __IOM uint32_t PTPTSLUR;
-  __IOM uint32_t PTPTSAR;
-  __IOM uint32_t PTPTTHR;
-  __IOM uint32_t PTPTTLR;
-  __IOM uint32_t RESERVED8;
-  __IOM uint32_t PTPTSSR;
+  __IO uint32_t PTPTSCR;
+  __IO uint32_t PTPSSIR;
+  __IO uint32_t PTPTSHR;
+  __IO uint32_t PTPTSLR;
+  __IO uint32_t PTPTSHUR;
+  __IO uint32_t PTPTSLUR;
+  __IO uint32_t PTPTSAR;
+  __IO uint32_t PTPTTHR;
+  __IO uint32_t PTPTTLR;
+  __IO uint32_t RESERVED8;
+  __IO uint32_t PTPTSSR;
   uint32_t      RESERVED9[565];
-  __IOM uint32_t DMABMR;
-  __IOM uint32_t DMATPDR;
-  __IOM uint32_t DMARPDR;
-  __IOM uint32_t DMARDLAR;
-  __IOM uint32_t DMATDLAR;
-  __IOM uint32_t DMASR;
-  __IOM uint32_t DMAOMR;
-  __IOM uint32_t DMAIER;
-  __IOM uint32_t DMAMFBOCR;
-  __IOM uint32_t DMARSWTR;
+  __IO uint32_t DMABMR;
+  __IO uint32_t DMATPDR;
+  __IO uint32_t DMARPDR;
+  __IO uint32_t DMARDLAR;
+  __IO uint32_t DMATDLAR;
+  __IO uint32_t DMASR;
+  __IO uint32_t DMAOMR;
+  __IO uint32_t DMAIER;
+  __IO uint32_t DMAMFBOCR;
+  __IO uint32_t DMARSWTR;
   uint32_t      RESERVED10[8];
-  __IOM uint32_t DMACHTDR;
-  __IOM uint32_t DMACHRDR;
-  __IOM uint32_t DMACHTBAR;
-  __IOM uint32_t DMACHRBAR;
+  __IO uint32_t DMACHTDR;
+  __IO uint32_t DMACHRDR;
+  __IO uint32_t DMACHTBAR;
+  __IO uint32_t DMACHRBAR;
 } ETH_TypeDef;
 
 /** 
@@ -481,12 +481,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -495,13 +495,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -510,7 +510,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
 } FMC_Bank1_TypeDef; 
 
 /** 
@@ -519,7 +519,7 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FMC_Bank1E_TypeDef;
 /** 
   * @brief Flexible Memory Controller Bank2
@@ -527,20 +527,20 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
-  __IOM uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
-  __IOM uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
-  __IOM uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
+  __IO uint32_t PCR2;       /*!< NAND Flash control register 2,                       Address offset: 0x60 */
+  __IO uint32_t SR2;        /*!< NAND Flash FIFO status and interrupt register 2,     Address offset: 0x64 */
+  __IO uint32_t PMEM2;      /*!< NAND Flash Common memory space timing register 2,    Address offset: 0x68 */
+  __IO uint32_t PATT2;      /*!< NAND Flash Attribute memory space timing register 2, Address offset: 0x6C */
   uint32_t      RESERVED0;  /*!< Reserved, 0x70                                                            */
-  __IOM uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
+  __IO uint32_t ECCR2;      /*!< NAND Flash ECC result registers 2,                   Address offset: 0x74 */
   uint32_t      RESERVED1;  /*!< Reserved, 0x78                                                            */
   uint32_t      RESERVED2;  /*!< Reserved, 0x7C                                                            */
-  __IOM uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
-  __IOM uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
-  __IOM uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
-  __IOM uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
+  __IO uint32_t PCR3;       /*!< NAND Flash control register 3,                       Address offset: 0x80 */
+  __IO uint32_t SR3;        /*!< NAND Flash FIFO status and interrupt register 3,     Address offset: 0x84 */
+  __IO uint32_t PMEM3;      /*!< NAND Flash Common memory space timing register 3,    Address offset: 0x88 */
+  __IO uint32_t PATT3;      /*!< NAND Flash Attribute memory space timing register 3, Address offset: 0x8C */
   uint32_t      RESERVED3;  /*!< Reserved, 0x90                                                            */
-  __IOM uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
+  __IO uint32_t ECCR3;      /*!< NAND Flash ECC result registers 3,                   Address offset: 0x94 */
 } FMC_Bank2_3_TypeDef;
 
 /** 
@@ -549,11 +549,11 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
-  __IOM uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
-  __IOM uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
-  __IOM uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
-  __IOM uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
+  __IO uint32_t PCR4;       /*!< PC Card  control register 4,                       Address offset: 0xA0 */
+  __IO uint32_t SR4;        /*!< PC Card  FIFO status and interrupt register 4,     Address offset: 0xA4 */
+  __IO uint32_t PMEM4;      /*!< PC Card  Common memory space timing register 4,    Address offset: 0xA8 */
+  __IO uint32_t PATT4;      /*!< PC Card  Attribute memory space timing register 4, Address offset: 0xAC */
+  __IO uint32_t PIO4;       /*!< PC Card  I/O space timing register 4,              Address offset: 0xB0 */
 } FMC_Bank4_TypeDef;
 
 /** 
@@ -562,11 +562,11 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
-  __IOM uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
-  __IOM uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
-  __IOM uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
-  __IOM uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
+  __IO uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
+  __IO uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
+  __IO uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
+  __IO uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
+  __IO uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
 } FMC_Bank5_6_TypeDef;
 
 /** 
@@ -575,15 +575,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -592,11 +592,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -605,16 +605,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /** 
@@ -623,10 +623,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 /** 
@@ -636,22 +636,22 @@ typedef struct
 typedef struct
 {
   uint32_t      RESERVED0[2];  /*!< Reserved, 0x00-0x04                                                       */
-  __IOM uint32_t SSCR;          /*!< LTDC Synchronization Size Configuration Register,    Address offset: 0x08 */
-  __IOM uint32_t BPCR;          /*!< LTDC Back Porch Configuration Register,              Address offset: 0x0C */
-  __IOM uint32_t AWCR;          /*!< LTDC Active Width Configuration Register,            Address offset: 0x10 */
-  __IOM uint32_t TWCR;          /*!< LTDC Total Width Configuration Register,             Address offset: 0x14 */
-  __IOM uint32_t GCR;           /*!< LTDC Global Control Register,                        Address offset: 0x18 */
+  __IO uint32_t SSCR;          /*!< LTDC Synchronization Size Configuration Register,    Address offset: 0x08 */
+  __IO uint32_t BPCR;          /*!< LTDC Back Porch Configuration Register,              Address offset: 0x0C */
+  __IO uint32_t AWCR;          /*!< LTDC Active Width Configuration Register,            Address offset: 0x10 */
+  __IO uint32_t TWCR;          /*!< LTDC Total Width Configuration Register,             Address offset: 0x14 */
+  __IO uint32_t GCR;           /*!< LTDC Global Control Register,                        Address offset: 0x18 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x1C-0x20                                                       */
-  __IOM uint32_t SRCR;          /*!< LTDC Shadow Reload Configuration Register,           Address offset: 0x24 */
+  __IO uint32_t SRCR;          /*!< LTDC Shadow Reload Configuration Register,           Address offset: 0x24 */
   uint32_t      RESERVED2[1];  /*!< Reserved, 0x28                                                            */
-  __IOM uint32_t BCCR;          /*!< LTDC Background Color Configuration Register,        Address offset: 0x2C */
+  __IO uint32_t BCCR;          /*!< LTDC Background Color Configuration Register,        Address offset: 0x2C */
   uint32_t      RESERVED3[1];  /*!< Reserved, 0x30                                                            */
-  __IOM uint32_t IER;           /*!< LTDC Interrupt Enable Register,                      Address offset: 0x34 */
-  __IOM uint32_t ISR;           /*!< LTDC Interrupt Status Register,                      Address offset: 0x38 */
-  __IOM uint32_t ICR;           /*!< LTDC Interrupt Clear Register,                       Address offset: 0x3C */
-  __IOM uint32_t LIPCR;         /*!< LTDC Line Interrupt Position Configuration Register, Address offset: 0x40 */
-  __IOM uint32_t CPSR;          /*!< LTDC Current Position Status Register,               Address offset: 0x44 */
-  __IOM uint32_t CDSR;          /*!< LTDC Current Display Status Register,                Address offset: 0x48 */
+  __IO uint32_t IER;           /*!< LTDC Interrupt Enable Register,                      Address offset: 0x34 */
+  __IO uint32_t ISR;           /*!< LTDC Interrupt Status Register,                      Address offset: 0x38 */
+  __IO uint32_t ICR;           /*!< LTDC Interrupt Clear Register,                       Address offset: 0x3C */
+  __IO uint32_t LIPCR;         /*!< LTDC Line Interrupt Position Configuration Register, Address offset: 0x40 */
+  __IO uint32_t CPSR;          /*!< LTDC Current Position Status Register,               Address offset: 0x44 */
+  __IO uint32_t CDSR;          /*!< LTDC Current Display Status Register,                Address offset: 0x48 */
 } LTDC_TypeDef;
 
 /** 
@@ -660,20 +660,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< LTDC Layerx Control Register                                  Address offset: 0x84 */
-  __IOM uint32_t WHPCR;         /*!< LTDC Layerx Window Horizontal Position Configuration Register Address offset: 0x88 */
-  __IOM uint32_t WVPCR;         /*!< LTDC Layerx Window Vertical Position Configuration Register   Address offset: 0x8C */
-  __IOM uint32_t CKCR;          /*!< LTDC Layerx Color Keying Configuration Register               Address offset: 0x90 */
-  __IOM uint32_t PFCR;          /*!< LTDC Layerx Pixel Format Configuration Register               Address offset: 0x94 */
-  __IOM uint32_t CACR;          /*!< LTDC Layerx Constant Alpha Configuration Register             Address offset: 0x98 */
-  __IOM uint32_t DCCR;          /*!< LTDC Layerx Default Color Configuration Register              Address offset: 0x9C */
-  __IOM uint32_t BFCR;          /*!< LTDC Layerx Blending Factors Configuration Register           Address offset: 0xA0 */
+  __IO uint32_t CR;            /*!< LTDC Layerx Control Register                                  Address offset: 0x84 */
+  __IO uint32_t WHPCR;         /*!< LTDC Layerx Window Horizontal Position Configuration Register Address offset: 0x88 */
+  __IO uint32_t WVPCR;         /*!< LTDC Layerx Window Vertical Position Configuration Register   Address offset: 0x8C */
+  __IO uint32_t CKCR;          /*!< LTDC Layerx Color Keying Configuration Register               Address offset: 0x90 */
+  __IO uint32_t PFCR;          /*!< LTDC Layerx Pixel Format Configuration Register               Address offset: 0x94 */
+  __IO uint32_t CACR;          /*!< LTDC Layerx Constant Alpha Configuration Register             Address offset: 0x98 */
+  __IO uint32_t DCCR;          /*!< LTDC Layerx Default Color Configuration Register              Address offset: 0x9C */
+  __IO uint32_t BFCR;          /*!< LTDC Layerx Blending Factors Configuration Register           Address offset: 0xA0 */
   uint32_t      RESERVED0[2];  /*!< Reserved                                                                           */
-  __IOM uint32_t CFBAR;         /*!< LTDC Layerx Color Frame Buffer Address Register               Address offset: 0xAC */
-  __IOM uint32_t CFBLR;         /*!< LTDC Layerx Color Frame Buffer Length Register                Address offset: 0xB0 */
-  __IOM uint32_t CFBLNR;        /*!< LTDC Layerx ColorFrame Buffer Line Number Register            Address offset: 0xB4 */
+  __IO uint32_t CFBAR;         /*!< LTDC Layerx Color Frame Buffer Address Register               Address offset: 0xAC */
+  __IO uint32_t CFBLR;         /*!< LTDC Layerx Color Frame Buffer Length Register                Address offset: 0xB0 */
+  __IO uint32_t CFBLNR;        /*!< LTDC Layerx ColorFrame Buffer Line Number Register            Address offset: 0xB4 */
   uint32_t      RESERVED1[3];  /*!< Reserved                                                                           */
-  __IOM uint32_t CLUTWR;        /*!< LTDC Layerx CLUT Write Register                               Address offset: 0x144*/
+  __IO uint32_t CLUTWR;        /*!< LTDC Layerx CLUT Write Register                               Address offset: 0x144*/
 } LTDC_Layer_TypeDef;
 
 /** 
@@ -682,8 +682,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -692,38 +692,38 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
-  __IOM uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
 } RCC_TypeDef;
 
 /** 
@@ -732,46 +732,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -780,19 +780,19 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
+  __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
 } SAI_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
-  __IOM uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
-  __IOM uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
-  __IOM uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
-  __IOM uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
-  __IOM uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
-  __IOM uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
+  __IO uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
+  __IO uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
+  __IO uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
+  __IO uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
+  __IO uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
+  __IO uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
+  __IO uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
 } SAI_Block_TypeDef;
 
 /** 
@@ -801,26 +801,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -829,15 +829,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 
@@ -847,27 +847,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -876,13 +876,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -891,9 +891,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -902,42 +902,42 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;         /*!< CRYP control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SR;         /*!< CRYP status register,                                     Address offset: 0x04 */
-  __IOM uint32_t DIN;         /*!< CRYP data input register,                                 Address offset: 0x08 */
-  __IOM uint32_t DOUT;       /*!< CRYP data output register,                                Address offset: 0x0C */
-  __IOM uint32_t DMACR;      /*!< CRYP DMA control register,                                Address offset: 0x10 */
-  __IOM uint32_t IMSCR;      /*!< CRYP interrupt mask set/clear register,                   Address offset: 0x14 */
-  __IOM uint32_t RISR;       /*!< CRYP raw interrupt status register,                       Address offset: 0x18 */
-  __IOM uint32_t MISR;       /*!< CRYP masked interrupt status register,                    Address offset: 0x1C */
-  __IOM uint32_t K0LR;       /*!< CRYP key left  register 0,                                Address offset: 0x20 */
-  __IOM uint32_t K0RR;       /*!< CRYP key right register 0,                                Address offset: 0x24 */
-  __IOM uint32_t K1LR;       /*!< CRYP key left  register 1,                                Address offset: 0x28 */
-  __IOM uint32_t K1RR;       /*!< CRYP key right register 1,                                Address offset: 0x2C */
-  __IOM uint32_t K2LR;       /*!< CRYP key left  register 2,                                Address offset: 0x30 */
-  __IOM uint32_t K2RR;       /*!< CRYP key right register 2,                                Address offset: 0x34 */
-  __IOM uint32_t K3LR;       /*!< CRYP key left  register 3,                                Address offset: 0x38 */
-  __IOM uint32_t K3RR;       /*!< CRYP key right register 3,                                Address offset: 0x3C */
-  __IOM uint32_t IV0LR;      /*!< CRYP initialization vector left-word  register 0,         Address offset: 0x40 */
-  __IOM uint32_t IV0RR;      /*!< CRYP initialization vector right-word register 0,         Address offset: 0x44 */
-  __IOM uint32_t IV1LR;      /*!< CRYP initialization vector left-word  register 1,         Address offset: 0x48 */
-  __IOM uint32_t IV1RR;      /*!< CRYP initialization vector right-word register 1,         Address offset: 0x4C */
-  __IOM uint32_t CSGCMCCM0R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 0,        Address offset: 0x50 */
-  __IOM uint32_t CSGCMCCM1R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 1,        Address offset: 0x54 */
-  __IOM uint32_t CSGCMCCM2R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 2,        Address offset: 0x58 */
-  __IOM uint32_t CSGCMCCM3R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 3,        Address offset: 0x5C */
-  __IOM uint32_t CSGCMCCM4R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 4,        Address offset: 0x60 */
-  __IOM uint32_t CSGCMCCM5R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 5,        Address offset: 0x64 */
-  __IOM uint32_t CSGCMCCM6R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 6,        Address offset: 0x68 */
-  __IOM uint32_t CSGCMCCM7R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 7,        Address offset: 0x6C */
-  __IOM uint32_t CSGCM0R;    /*!< CRYP GCM/GMAC context swap register 0,                    Address offset: 0x70 */
-  __IOM uint32_t CSGCM1R;    /*!< CRYP GCM/GMAC context swap register 1,                    Address offset: 0x74 */
-  __IOM uint32_t CSGCM2R;    /*!< CRYP GCM/GMAC context swap register 2,                    Address offset: 0x78 */
-  __IOM uint32_t CSGCM3R;    /*!< CRYP GCM/GMAC context swap register 3,                    Address offset: 0x7C */
-  __IOM uint32_t CSGCM4R;    /*!< CRYP GCM/GMAC context swap register 4,                    Address offset: 0x80 */
-  __IOM uint32_t CSGCM5R;    /*!< CRYP GCM/GMAC context swap register 5,                    Address offset: 0x84 */
-  __IOM uint32_t CSGCM6R;    /*!< CRYP GCM/GMAC context swap register 6,                    Address offset: 0x88 */
-  __IOM uint32_t CSGCM7R;    /*!< CRYP GCM/GMAC context swap register 7,                    Address offset: 0x8C */
+  __IO uint32_t CR;         /*!< CRYP control register,                                    Address offset: 0x00 */
+  __IO uint32_t SR;         /*!< CRYP status register,                                     Address offset: 0x04 */
+  __IO uint32_t DIN;         /*!< CRYP data input register,                                 Address offset: 0x08 */
+  __IO uint32_t DOUT;       /*!< CRYP data output register,                                Address offset: 0x0C */
+  __IO uint32_t DMACR;      /*!< CRYP DMA control register,                                Address offset: 0x10 */
+  __IO uint32_t IMSCR;      /*!< CRYP interrupt mask set/clear register,                   Address offset: 0x14 */
+  __IO uint32_t RISR;       /*!< CRYP raw interrupt status register,                       Address offset: 0x18 */
+  __IO uint32_t MISR;       /*!< CRYP masked interrupt status register,                    Address offset: 0x1C */
+  __IO uint32_t K0LR;       /*!< CRYP key left  register 0,                                Address offset: 0x20 */
+  __IO uint32_t K0RR;       /*!< CRYP key right register 0,                                Address offset: 0x24 */
+  __IO uint32_t K1LR;       /*!< CRYP key left  register 1,                                Address offset: 0x28 */
+  __IO uint32_t K1RR;       /*!< CRYP key right register 1,                                Address offset: 0x2C */
+  __IO uint32_t K2LR;       /*!< CRYP key left  register 2,                                Address offset: 0x30 */
+  __IO uint32_t K2RR;       /*!< CRYP key right register 2,                                Address offset: 0x34 */
+  __IO uint32_t K3LR;       /*!< CRYP key left  register 3,                                Address offset: 0x38 */
+  __IO uint32_t K3RR;       /*!< CRYP key right register 3,                                Address offset: 0x3C */
+  __IO uint32_t IV0LR;      /*!< CRYP initialization vector left-word  register 0,         Address offset: 0x40 */
+  __IO uint32_t IV0RR;      /*!< CRYP initialization vector right-word register 0,         Address offset: 0x44 */
+  __IO uint32_t IV1LR;      /*!< CRYP initialization vector left-word  register 1,         Address offset: 0x48 */
+  __IO uint32_t IV1RR;      /*!< CRYP initialization vector right-word register 1,         Address offset: 0x4C */
+  __IO uint32_t CSGCMCCM0R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 0,        Address offset: 0x50 */
+  __IO uint32_t CSGCMCCM1R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 1,        Address offset: 0x54 */
+  __IO uint32_t CSGCMCCM2R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 2,        Address offset: 0x58 */
+  __IO uint32_t CSGCMCCM3R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 3,        Address offset: 0x5C */
+  __IO uint32_t CSGCMCCM4R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 4,        Address offset: 0x60 */
+  __IO uint32_t CSGCMCCM5R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 5,        Address offset: 0x64 */
+  __IO uint32_t CSGCMCCM6R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 6,        Address offset: 0x68 */
+  __IO uint32_t CSGCMCCM7R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 7,        Address offset: 0x6C */
+  __IO uint32_t CSGCM0R;    /*!< CRYP GCM/GMAC context swap register 0,                    Address offset: 0x70 */
+  __IO uint32_t CSGCM1R;    /*!< CRYP GCM/GMAC context swap register 1,                    Address offset: 0x74 */
+  __IO uint32_t CSGCM2R;    /*!< CRYP GCM/GMAC context swap register 2,                    Address offset: 0x78 */
+  __IO uint32_t CSGCM3R;    /*!< CRYP GCM/GMAC context swap register 3,                    Address offset: 0x7C */
+  __IO uint32_t CSGCM4R;    /*!< CRYP GCM/GMAC context swap register 4,                    Address offset: 0x80 */
+  __IO uint32_t CSGCM5R;    /*!< CRYP GCM/GMAC context swap register 5,                    Address offset: 0x84 */
+  __IO uint32_t CSGCM6R;    /*!< CRYP GCM/GMAC context swap register 6,                    Address offset: 0x88 */
+  __IO uint32_t CSGCM7R;    /*!< CRYP GCM/GMAC context swap register 7,                    Address offset: 0x8C */
 } CRYP_TypeDef;
 
 /** 
@@ -946,14 +946,14 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;               /*!< HASH control register,          Address offset: 0x00        */
-  __IOM uint32_t DIN;              /*!< HASH data input register,       Address offset: 0x04        */
-  __IOM uint32_t STR;              /*!< HASH start register,            Address offset: 0x08        */
-  __IOM uint32_t HR[5];            /*!< HASH digest registers,          Address offset: 0x0C-0x1C   */
-  __IOM uint32_t IMR;              /*!< HASH interrupt enable register, Address offset: 0x20        */
-  __IOM uint32_t SR;               /*!< HASH status register,           Address offset: 0x24        */
+  __IO uint32_t CR;               /*!< HASH control register,          Address offset: 0x00        */
+  __IO uint32_t DIN;              /*!< HASH data input register,       Address offset: 0x04        */
+  __IO uint32_t STR;              /*!< HASH start register,            Address offset: 0x08        */
+  __IO uint32_t HR[5];            /*!< HASH digest registers,          Address offset: 0x0C-0x1C   */
+  __IO uint32_t IMR;              /*!< HASH interrupt enable register, Address offset: 0x20        */
+  __IO uint32_t SR;               /*!< HASH status register,           Address offset: 0x24        */
        uint32_t RESERVED[52];     /*!< Reserved, 0x28-0xF4                                         */
-  __IOM uint32_t CSR[54];          /*!< HASH context swap registers,    Address offset: 0x0F8-0x1CC */
+  __IO uint32_t CSR[54];          /*!< HASH context swap registers,    Address offset: 0x0F8-0x1CC */
 } HASH_TypeDef;
 
 /** 
@@ -962,7 +962,7 @@ typedef struct
 
 typedef struct 
 {
-  __IOM uint32_t HR[8];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */ 
+  __IO uint32_t HR[8];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */ 
 } HASH_DIGEST_TypeDef;
 
 /** 
@@ -971,9 +971,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -981,24 +981,24 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved40[48];           /*!< Reserved                                0x40-0xFF */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -1006,26 +1006,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -1033,13 +1033,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -1048,12 +1048,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -1062,13 +1062,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -1076,12 +1076,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f446xx.h
+++ b/Include/stm32f446xx.h
@@ -181,33 +181,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -218,10 +218,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -230,10 +230,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -242,8 +242,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -252,26 +252,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -283,12 +283,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;           /*!< CEC control register,              Address offset:0x00 */
-  __IOM uint32_t CFGR;         /*!< CEC configuration register,        Address offset:0x04 */
-  __IOM uint32_t TXDR;         /*!< CEC Tx data register ,             Address offset:0x08 */
-  __IOM uint32_t RXDR;         /*!< CEC Rx Data Register,              Address offset:0x0C */
-  __IOM uint32_t ISR;          /*!< CEC Interrupt and Status Register, Address offset:0x10 */
-  __IOM uint32_t IER;          /*!< CEC interrupt enable register,     Address offset:0x14 */
+  __IO uint32_t CR;           /*!< CEC control register,              Address offset:0x00 */
+  __IO uint32_t CFGR;         /*!< CEC configuration register,        Address offset:0x04 */
+  __IO uint32_t TXDR;         /*!< CEC Tx data register ,             Address offset:0x08 */
+  __IO uint32_t RXDR;         /*!< CEC Rx Data Register,              Address offset:0x0C */
+  __IO uint32_t ISR;          /*!< CEC Interrupt and Status Register, Address offset:0x10 */
+  __IO uint32_t IER;          /*!< CEC interrupt enable register,     Address offset:0x14 */
 }CEC_TypeDef;
 /** 
   * @brief CRC calculation unit 
@@ -296,11 +296,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -309,20 +309,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -331,10 +331,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 /** 
@@ -343,17 +343,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
-  __IOM uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
-  __IOM uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
-  __IOM uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
-  __IOM uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
-  __IOM uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
-  __IOM uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
-  __IOM uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
-  __IOM uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
-  __IOM uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
-  __IOM uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
+  __IO uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
+  __IO uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
+  __IO uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
+  __IO uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
+  __IO uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
+  __IO uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
+  __IO uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
+  __IO uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
+  __IO uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
+  __IO uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
+  __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
 } DCMI_TypeDef;
 
 /** 
@@ -362,20 +362,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -384,12 +384,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -398,13 +398,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -413,7 +413,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
 } FMC_Bank1_TypeDef; 
 
 /** 
@@ -422,7 +422,7 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FMC_Bank1E_TypeDef;
 
 /** 
@@ -431,12 +431,12 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t PCR;       /*!< NAND Flash control register,                       Address offset: 0x80 */
-  __IOM uint32_t SR;        /*!< NAND Flash FIFO status and interrupt register,     Address offset: 0x84 */
-  __IOM uint32_t PMEM;      /*!< NAND Flash Common memory space timing register,    Address offset: 0x88 */
-  __IOM uint32_t PATT;      /*!< NAND Flash Attribute memory space timing register, Address offset: 0x8C */
+  __IO uint32_t PCR;       /*!< NAND Flash control register,                       Address offset: 0x80 */
+  __IO uint32_t SR;        /*!< NAND Flash FIFO status and interrupt register,     Address offset: 0x84 */
+  __IO uint32_t PMEM;      /*!< NAND Flash Common memory space timing register,    Address offset: 0x88 */
+  __IO uint32_t PATT;      /*!< NAND Flash Attribute memory space timing register, Address offset: 0x8C */
   uint32_t      RESERVED;  /*!< Reserved, 0x90                                                          */
-  __IOM uint32_t ECCR;      /*!< NAND Flash ECC result registers,                   Address offset: 0x94 */
+  __IO uint32_t ECCR;      /*!< NAND Flash ECC result registers,                   Address offset: 0x94 */
 } FMC_Bank3_TypeDef;
 
 /** 
@@ -445,11 +445,11 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
-  __IOM uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
-  __IOM uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
-  __IOM uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
-  __IOM uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
+  __IO uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
+  __IO uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
+  __IO uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
+  __IO uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
+  __IO uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
 } FMC_Bank5_6_TypeDef;
 
 /** 
@@ -458,15 +458,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -475,13 +475,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
   uint32_t      RESERVED1[2]; /*!< Reserved, 0x24-0x28                                                          */
-  __IOM uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x2C      */
+  __IO uint32_t CFGR;         /*!< SYSCFG Configuration register,                     Address offset: 0x2C      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -490,16 +490,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /**
@@ -508,17 +508,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
-  __IOM uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
-  __IOM uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
-  __IOM uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
-  __IOM uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
-  __IOM uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
-  __IOM uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
-  __IOM uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
-  __IOM uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
-  __IOM uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
+  __IO uint32_t CR1;         /*!< FMPI2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< FMPI2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< FMPI2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< FMPI2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< FMPI2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< FMPI2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< FMPI2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< FMPI2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< FMPI2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< FMPI2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< FMPI2C Transmit data register,        Address offset: 0x28 */
 } FMPI2C_TypeDef;
 
 /** 
@@ -527,10 +527,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 
@@ -540,8 +540,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -550,40 +550,40 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
-  __IOM uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
-  __IOM uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                            Address offset: 0x90 */
-  __IOM uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t CKGATENR;      /*!< RCC Clocks Gated ENable Register,                            Address offset: 0x90 */
+  __IO uint32_t DCKCFGR2;      /*!< RCC Dedicated Clocks configuration register 2,               Address offset: 0x94 */
 } RCC_TypeDef;
 
 /** 
@@ -592,46 +592,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -640,19 +640,19 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
+  __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
 } SAI_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
-  __IOM uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
-  __IOM uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
-  __IOM uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
-  __IOM uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
-  __IOM uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
-  __IOM uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
+  __IO uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
+  __IO uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
+  __IO uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
+  __IO uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
+  __IO uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
+  __IO uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
+  __IO uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
 } SAI_Block_TypeDef;
 
 /** 
@@ -661,26 +661,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -689,15 +689,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 /** 
@@ -706,19 +706,19 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
-  __IOM uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
-  __IOM uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
-  __IOM uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
-  __IOM uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
-  __IOM uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
-  __IOM uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
-  __IOM uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
-  __IOM uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
-  __IOM uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
-  __IOM uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
-  __IOM uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
+  __IO uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
+  __IO uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
+  __IO uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
+  __IO uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
+  __IO uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
+  __IO uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
+  __IO uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
+  __IO uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
+  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
+  __IO uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
+  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
 } QUADSPI_TypeDef;
 
 /** 
@@ -727,15 +727,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t   CR;           /*!< Control register,                   Address offset: 0x00 */
-  __IOM uint16_t   IMR;          /*!< Interrupt mask register,            Address offset: 0x04 */
+  __IO uint32_t   CR;           /*!< Control register,                   Address offset: 0x00 */
+  __IO uint16_t   IMR;          /*!< Interrupt mask register,            Address offset: 0x04 */
   uint16_t        RESERVED0;    /*!< Reserved,  0x06                                          */
-  __IOM uint32_t   SR;           /*!< Status register,                    Address offset: 0x08 */
-  __IOM uint16_t   IFCR;         /*!< Interrupt Flag Clear register,      Address offset: 0x0C */
+  __IO uint32_t   SR;           /*!< Status register,                    Address offset: 0x08 */
+  __IO uint16_t   IFCR;         /*!< Interrupt Flag Clear register,      Address offset: 0x0C */
   uint16_t        RESERVED1;    /*!< Reserved,  0x0E                                          */
-  __IOM uint32_t   DR;           /*!< Data input register,                Address offset: 0x10 */
-  __IOM uint32_t   CSR;          /*!< Channel Status register,            Address offset: 0x14 */
-   __IOM uint32_t  DIR;          /*!< Debug Information register,         Address offset: 0x18 */
+  __IO uint32_t   DR;           /*!< Data input register,                Address offset: 0x10 */
+  __IO uint32_t   CSR;          /*!< Channel Status register,            Address offset: 0x14 */
+   __IO uint32_t  DIR;          /*!< Debug Information register,         Address offset: 0x18 */
   uint16_t        RESERVED2;    /*!< Reserved,  0x1A                                          */
 } SPDIFRX_TypeDef;
 
@@ -745,27 +745,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -774,13 +774,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -789,39 +789,39 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 /** 
   * @brief USB_OTG_Core_Registers
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved5[3];             /*!< Reserved                                040h-048h */
-  __IOM uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
+  __IO uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
   uint32_t  Reserved6;                /*!< Reserved                                     050h */
-  __IOM uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
+  __IO uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
   uint32_t  Reserved;                 /*!< Reserved                                     058h */
-  __IOM uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
+  __IO uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
   uint32_t  Reserved43[40];           /*!< Reserved                                058h-0FFh */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -829,26 +829,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -856,13 +856,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -871,12 +871,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -885,13 +885,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -899,12 +899,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f469xx.h
+++ b/Include/stm32f469xx.h
@@ -187,33 +187,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -224,10 +224,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -236,10 +236,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -248,8 +248,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -258,26 +258,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -288,11 +288,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -301,20 +301,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -323,10 +323,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 /** 
@@ -335,17 +335,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
-  __IOM uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
-  __IOM uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
-  __IOM uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
-  __IOM uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
-  __IOM uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
-  __IOM uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
-  __IOM uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
-  __IOM uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
-  __IOM uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
-  __IOM uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
+  __IO uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
+  __IO uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
+  __IO uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
+  __IO uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
+  __IO uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
+  __IO uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
+  __IO uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
+  __IO uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
+  __IO uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
+  __IO uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
+  __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
 } DCMI_TypeDef;
 
 /** 
@@ -354,20 +354,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -376,29 +376,29 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
-  __IOM uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
-  __IOM uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
-  __IOM uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
-  __IOM uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
-  __IOM uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
-  __IOM uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
-  __IOM uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
-  __IOM uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
-  __IOM uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
-  __IOM uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
-  __IOM uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
-  __IOM uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
-  __IOM uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
-  __IOM uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
-  __IOM uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
-  __IOM uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
-  __IOM uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
-  __IOM uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
-  __IOM uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
+  __IO uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
+  __IO uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
+  __IO uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
+  __IO uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
+  __IO uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
+  __IO uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
+  __IO uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
+  __IO uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
+  __IO uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
+  __IO uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
+  __IO uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
+  __IO uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
+  __IO uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
+  __IO uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
+  __IO uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
+  __IO uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
+  __IO uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
+  __IO uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
+  __IO uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
+  __IO uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
   uint32_t      RESERVED[236]; /*!< Reserved, 0x50-0x3FF */
-  __IOM uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
-  __IOM uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
+  __IO uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
+  __IO uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
 } DMA2D_TypeDef;
 
 /** 
@@ -407,79 +407,79 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t VR;            /*!< DSI Host Version Register,                                 Address offset: 0x00        */
-  __IOM uint32_t CR;            /*!< DSI Host Control Register,                                 Address offset: 0x04        */
-  __IOM uint32_t CCR;           /*!< DSI HOST Clock Control Register,                           Address offset: 0x08        */
-  __IOM uint32_t LVCIDR;        /*!< DSI Host LTDC VCID Register,                               Address offset: 0x0C        */
-  __IOM uint32_t LCOLCR;        /*!< DSI Host LTDC Color Coding Register,                       Address offset: 0x10        */
-  __IOM uint32_t LPCR;          /*!< DSI Host LTDC Polarity Configuration Register,             Address offset: 0x14        */
-  __IOM uint32_t LPMCR;         /*!< DSI Host Low-Power Mode Configuration Register,            Address offset: 0x18        */
+  __IO uint32_t VR;            /*!< DSI Host Version Register,                                 Address offset: 0x00        */
+  __IO uint32_t CR;            /*!< DSI Host Control Register,                                 Address offset: 0x04        */
+  __IO uint32_t CCR;           /*!< DSI HOST Clock Control Register,                           Address offset: 0x08        */
+  __IO uint32_t LVCIDR;        /*!< DSI Host LTDC VCID Register,                               Address offset: 0x0C        */
+  __IO uint32_t LCOLCR;        /*!< DSI Host LTDC Color Coding Register,                       Address offset: 0x10        */
+  __IO uint32_t LPCR;          /*!< DSI Host LTDC Polarity Configuration Register,             Address offset: 0x14        */
+  __IO uint32_t LPMCR;         /*!< DSI Host Low-Power Mode Configuration Register,            Address offset: 0x18        */
   uint32_t      RESERVED0[4];  /*!< Reserved, 0x1C - 0x2B                                                                  */
-  __IOM uint32_t PCR;           /*!< DSI Host Protocol Configuration Register,                  Address offset: 0x2C        */
-  __IOM uint32_t GVCIDR;        /*!< DSI Host Generic VCID Register,                            Address offset: 0x30        */
-  __IOM uint32_t MCR;           /*!< DSI Host Mode Configuration Register,                      Address offset: 0x34        */
-  __IOM uint32_t VMCR;          /*!< DSI Host Video Mode Configuration Register,                Address offset: 0x38        */
-  __IOM uint32_t VPCR;          /*!< DSI Host Video Packet Configuration Register,              Address offset: 0x3C        */
-  __IOM uint32_t VCCR;          /*!< DSI Host Video Chunks Configuration Register,              Address offset: 0x40        */
-  __IOM uint32_t VNPCR;         /*!< DSI Host Video Null Packet Configuration Register,         Address offset: 0x44        */
-  __IOM uint32_t VHSACR;        /*!< DSI Host Video HSA Configuration Register,                 Address offset: 0x48        */
-  __IOM uint32_t VHBPCR;        /*!< DSI Host Video HBP Configuration Register,                 Address offset: 0x4C        */
-  __IOM uint32_t VLCR;          /*!< DSI Host Video Line Configuration Register,                Address offset: 0x50        */
-  __IOM uint32_t VVSACR;        /*!< DSI Host Video VSA Configuration Register,                 Address offset: 0x54        */
-  __IOM uint32_t VVBPCR;        /*!< DSI Host Video VBP Configuration Register,                 Address offset: 0x58        */
-  __IOM uint32_t VVFPCR;        /*!< DSI Host Video VFP Configuration Register,                 Address offset: 0x5C        */
-  __IOM uint32_t VVACR;         /*!< DSI Host Video VA Configuration Register,                  Address offset: 0x60        */
-  __IOM uint32_t LCCR;          /*!< DSI Host LTDC Command Configuration Register,              Address offset: 0x64        */
-  __IOM uint32_t CMCR;          /*!< DSI Host Command Mode Configuration Register,              Address offset: 0x68        */
-  __IOM uint32_t GHCR;          /*!< DSI Host Generic Header Configuration Register,            Address offset: 0x6C        */
-  __IOM uint32_t GPDR;          /*!< DSI Host Generic Payload Data Register,                    Address offset: 0x70        */
-  __IOM uint32_t GPSR;          /*!< DSI Host Generic Packet Status Register,                   Address offset: 0x74        */
-  __IOM uint32_t TCCR[6];       /*!< DSI Host Timeout Counter Configuration Register,           Address offset: 0x78-0x8F   */
-  __IOM uint32_t TDCR;          /*!< DSI Host 3D Configuration Register,                        Address offset: 0x90        */
-  __IOM uint32_t CLCR;          /*!< DSI Host Clock Lane Configuration Register,                Address offset: 0x94        */
-  __IOM uint32_t CLTCR;         /*!< DSI Host Clock Lane Timer Configuration Register,          Address offset: 0x98        */
-  __IOM uint32_t DLTCR;         /*!< DSI Host Data Lane Timer Configuration Register,           Address offset: 0x9C        */
-  __IOM uint32_t PCTLR;         /*!< DSI Host PHY Control Register,                             Address offset: 0xA0        */
-  __IOM uint32_t PCONFR;        /*!< DSI Host PHY Configuration Register,                       Address offset: 0xA4        */
-  __IOM uint32_t PUCR;          /*!< DSI Host PHY ULPS Control Register,                        Address offset: 0xA8        */
-  __IOM uint32_t PTTCR;         /*!< DSI Host PHY TX Triggers Configuration Register,           Address offset: 0xAC        */
-  __IOM uint32_t PSR;           /*!< DSI Host PHY Status Register,                              Address offset: 0xB0        */
+  __IO uint32_t PCR;           /*!< DSI Host Protocol Configuration Register,                  Address offset: 0x2C        */
+  __IO uint32_t GVCIDR;        /*!< DSI Host Generic VCID Register,                            Address offset: 0x30        */
+  __IO uint32_t MCR;           /*!< DSI Host Mode Configuration Register,                      Address offset: 0x34        */
+  __IO uint32_t VMCR;          /*!< DSI Host Video Mode Configuration Register,                Address offset: 0x38        */
+  __IO uint32_t VPCR;          /*!< DSI Host Video Packet Configuration Register,              Address offset: 0x3C        */
+  __IO uint32_t VCCR;          /*!< DSI Host Video Chunks Configuration Register,              Address offset: 0x40        */
+  __IO uint32_t VNPCR;         /*!< DSI Host Video Null Packet Configuration Register,         Address offset: 0x44        */
+  __IO uint32_t VHSACR;        /*!< DSI Host Video HSA Configuration Register,                 Address offset: 0x48        */
+  __IO uint32_t VHBPCR;        /*!< DSI Host Video HBP Configuration Register,                 Address offset: 0x4C        */
+  __IO uint32_t VLCR;          /*!< DSI Host Video Line Configuration Register,                Address offset: 0x50        */
+  __IO uint32_t VVSACR;        /*!< DSI Host Video VSA Configuration Register,                 Address offset: 0x54        */
+  __IO uint32_t VVBPCR;        /*!< DSI Host Video VBP Configuration Register,                 Address offset: 0x58        */
+  __IO uint32_t VVFPCR;        /*!< DSI Host Video VFP Configuration Register,                 Address offset: 0x5C        */
+  __IO uint32_t VVACR;         /*!< DSI Host Video VA Configuration Register,                  Address offset: 0x60        */
+  __IO uint32_t LCCR;          /*!< DSI Host LTDC Command Configuration Register,              Address offset: 0x64        */
+  __IO uint32_t CMCR;          /*!< DSI Host Command Mode Configuration Register,              Address offset: 0x68        */
+  __IO uint32_t GHCR;          /*!< DSI Host Generic Header Configuration Register,            Address offset: 0x6C        */
+  __IO uint32_t GPDR;          /*!< DSI Host Generic Payload Data Register,                    Address offset: 0x70        */
+  __IO uint32_t GPSR;          /*!< DSI Host Generic Packet Status Register,                   Address offset: 0x74        */
+  __IO uint32_t TCCR[6];       /*!< DSI Host Timeout Counter Configuration Register,           Address offset: 0x78-0x8F   */
+  __IO uint32_t TDCR;          /*!< DSI Host 3D Configuration Register,                        Address offset: 0x90        */
+  __IO uint32_t CLCR;          /*!< DSI Host Clock Lane Configuration Register,                Address offset: 0x94        */
+  __IO uint32_t CLTCR;         /*!< DSI Host Clock Lane Timer Configuration Register,          Address offset: 0x98        */
+  __IO uint32_t DLTCR;         /*!< DSI Host Data Lane Timer Configuration Register,           Address offset: 0x9C        */
+  __IO uint32_t PCTLR;         /*!< DSI Host PHY Control Register,                             Address offset: 0xA0        */
+  __IO uint32_t PCONFR;        /*!< DSI Host PHY Configuration Register,                       Address offset: 0xA4        */
+  __IO uint32_t PUCR;          /*!< DSI Host PHY ULPS Control Register,                        Address offset: 0xA8        */
+  __IO uint32_t PTTCR;         /*!< DSI Host PHY TX Triggers Configuration Register,           Address offset: 0xAC        */
+  __IO uint32_t PSR;           /*!< DSI Host PHY Status Register,                              Address offset: 0xB0        */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0xB4 - 0xBB                                                                  */
-  __IOM uint32_t ISR[2];        /*!< DSI Host Interrupt & Status Register,                      Address offset: 0xBC-0xC3   */
-  __IOM uint32_t IER[2];        /*!< DSI Host Interrupt Enable Register,                        Address offset: 0xC4-0xCB   */
+  __IO uint32_t ISR[2];        /*!< DSI Host Interrupt & Status Register,                      Address offset: 0xBC-0xC3   */
+  __IO uint32_t IER[2];        /*!< DSI Host Interrupt Enable Register,                        Address offset: 0xC4-0xCB   */
   uint32_t      RESERVED2[3];  /*!< Reserved, 0xD0 - 0xD7                                                                  */
-  __IOM uint32_t FIR[2];        /*!< DSI Host Force Interrupt Register,                         Address offset: 0xD8-0xDF   */
+  __IO uint32_t FIR[2];        /*!< DSI Host Force Interrupt Register,                         Address offset: 0xD8-0xDF   */
   uint32_t      RESERVED3[8];  /*!< Reserved, 0xE0 - 0xFF                                                                  */
-  __IOM uint32_t VSCR;          /*!< DSI Host Video Shadow Control Register,                    Address offset: 0x100       */
+  __IO uint32_t VSCR;          /*!< DSI Host Video Shadow Control Register,                    Address offset: 0x100       */
   uint32_t      RESERVED4[2];  /*!< Reserved, 0x104 - 0x10B                                                                */
-  __IOM uint32_t LCVCIDR;       /*!< DSI Host LTDC Current VCID Register,                       Address offset: 0x10C       */
-  __IOM uint32_t LCCCR;         /*!< DSI Host LTDC Current Color Coding Register,               Address offset: 0x110       */
+  __IO uint32_t LCVCIDR;       /*!< DSI Host LTDC Current VCID Register,                       Address offset: 0x10C       */
+  __IO uint32_t LCCCR;         /*!< DSI Host LTDC Current Color Coding Register,               Address offset: 0x110       */
   uint32_t      RESERVED5;     /*!< Reserved, 0x114                                                                        */
-  __IOM uint32_t LPMCCR;        /*!< DSI Host Low-power Mode Current Configuration Register,    Address offset: 0x118       */
+  __IO uint32_t LPMCCR;        /*!< DSI Host Low-power Mode Current Configuration Register,    Address offset: 0x118       */
   uint32_t      RESERVED6[7];  /*!< Reserved, 0x11C - 0x137                                                                */
-  __IOM uint32_t VMCCR;         /*!< DSI Host Video Mode Current Configuration Register,        Address offset: 0x138       */
-  __IOM uint32_t VPCCR;         /*!< DSI Host Video Packet Current Configuration Register,      Address offset: 0x13C       */
-  __IOM uint32_t VCCCR;         /*!< DSI Host Video Chuncks Current Configuration Register,     Address offset: 0x140       */
-  __IOM uint32_t VNPCCR;        /*!< DSI Host Video Null Packet Current Configuration Register, Address offset: 0x144       */
-  __IOM uint32_t VHSACCR;       /*!< DSI Host Video HSA Current Configuration Register,         Address offset: 0x148       */
-  __IOM uint32_t VHBPCCR;       /*!< DSI Host Video HBP Current Configuration Register,         Address offset: 0x14C       */
-  __IOM uint32_t VLCCR;         /*!< DSI Host Video Line Current Configuration Register,        Address offset: 0x150       */
-  __IOM uint32_t VVSACCR;       /*!< DSI Host Video VSA Current Configuration Register,         Address offset: 0x154       */
-  __IOM uint32_t VVBPCCR;       /*!< DSI Host Video VBP Current Configuration Register,         Address offset: 0x158       */
-  __IOM uint32_t VVFPCCR;       /*!< DSI Host Video VFP Current Configuration Register,         Address offset: 0x15C       */
-  __IOM uint32_t VVACCR;        /*!< DSI Host Video VA Current Configuration Register,          Address offset: 0x160       */
+  __IO uint32_t VMCCR;         /*!< DSI Host Video Mode Current Configuration Register,        Address offset: 0x138       */
+  __IO uint32_t VPCCR;         /*!< DSI Host Video Packet Current Configuration Register,      Address offset: 0x13C       */
+  __IO uint32_t VCCCR;         /*!< DSI Host Video Chuncks Current Configuration Register,     Address offset: 0x140       */
+  __IO uint32_t VNPCCR;        /*!< DSI Host Video Null Packet Current Configuration Register, Address offset: 0x144       */
+  __IO uint32_t VHSACCR;       /*!< DSI Host Video HSA Current Configuration Register,         Address offset: 0x148       */
+  __IO uint32_t VHBPCCR;       /*!< DSI Host Video HBP Current Configuration Register,         Address offset: 0x14C       */
+  __IO uint32_t VLCCR;         /*!< DSI Host Video Line Current Configuration Register,        Address offset: 0x150       */
+  __IO uint32_t VVSACCR;       /*!< DSI Host Video VSA Current Configuration Register,         Address offset: 0x154       */
+  __IO uint32_t VVBPCCR;       /*!< DSI Host Video VBP Current Configuration Register,         Address offset: 0x158       */
+  __IO uint32_t VVFPCCR;       /*!< DSI Host Video VFP Current Configuration Register,         Address offset: 0x15C       */
+  __IO uint32_t VVACCR;        /*!< DSI Host Video VA Current Configuration Register,          Address offset: 0x160       */
   uint32_t      RESERVED7[11]; /*!< Reserved, 0x164 - 0x18F                                                                */
-  __IOM uint32_t TDCCR;         /*!< DSI Host 3D Current Configuration Register,                Address offset: 0x190       */
+  __IO uint32_t TDCCR;         /*!< DSI Host 3D Current Configuration Register,                Address offset: 0x190       */
   uint32_t      RESERVED8[155]; /*!< Reserved, 0x194 - 0x3FF                                                               */
-  __IOM uint32_t WCFGR;          /*!< DSI Wrapper Configuration Register,                       Address offset: 0x400       */
-  __IOM uint32_t WCR;            /*!< DSI Wrapper Control Register,                             Address offset: 0x404       */
-  __IOM uint32_t WIER;           /*!< DSI Wrapper Interrupt Enable Register,                    Address offset: 0x408       */
-  __IOM uint32_t WISR;           /*!< DSI Wrapper Interrupt and Status Register,                Address offset: 0x40C       */
-  __IOM uint32_t WIFCR;          /*!< DSI Wrapper Interrupt Flag Clear Register,                Address offset: 0x410       */
+  __IO uint32_t WCFGR;          /*!< DSI Wrapper Configuration Register,                       Address offset: 0x400       */
+  __IO uint32_t WCR;            /*!< DSI Wrapper Control Register,                             Address offset: 0x404       */
+  __IO uint32_t WIER;           /*!< DSI Wrapper Interrupt Enable Register,                    Address offset: 0x408       */
+  __IO uint32_t WISR;           /*!< DSI Wrapper Interrupt and Status Register,                Address offset: 0x40C       */
+  __IO uint32_t WIFCR;          /*!< DSI Wrapper Interrupt Flag Clear Register,                Address offset: 0x410       */
   uint32_t      RESERVED9;      /*!< Reserved, 0x414                                                                       */
-  __IOM uint32_t WPCR[5];        /*!< DSI Wrapper PHY Configuration Register,                   Address offset: 0x418-0x42B */
+  __IO uint32_t WPCR[5];        /*!< DSI Wrapper PHY Configuration Register,                   Address offset: 0x418-0x42B */
   uint32_t      RESERVED10;     /*!< Reserved, 0x42C                                                                       */
-  __IOM uint32_t WRPCR;          /*!< DSI Wrapper Regulator and PLL Control Register, Address offset: 0x430                 */
+  __IO uint32_t WRPCR;          /*!< DSI Wrapper Regulator and PLL Control Register, Address offset: 0x430                 */
 } DSI_TypeDef;
 
 /** 
@@ -488,73 +488,73 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MACCR;
-  __IOM uint32_t MACFFR;
-  __IOM uint32_t MACHTHR;
-  __IOM uint32_t MACHTLR;
-  __IOM uint32_t MACMIIAR;
-  __IOM uint32_t MACMIIDR;
-  __IOM uint32_t MACFCR;
-  __IOM uint32_t MACVLANTR;             /*    8 */
+  __IO uint32_t MACCR;
+  __IO uint32_t MACFFR;
+  __IO uint32_t MACHTHR;
+  __IO uint32_t MACHTLR;
+  __IO uint32_t MACMIIAR;
+  __IO uint32_t MACMIIDR;
+  __IO uint32_t MACFCR;
+  __IO uint32_t MACVLANTR;             /*    8 */
   uint32_t      RESERVED0[2];
-  __IOM uint32_t MACRWUFFR;             /*   11 */
-  __IOM uint32_t MACPMTCSR;
+  __IO uint32_t MACRWUFFR;             /*   11 */
+  __IO uint32_t MACPMTCSR;
   uint32_t      RESERVED1;
-  __IOM uint32_t MACDBGR;
-  __IOM uint32_t MACSR;                 /*   15 */
-  __IOM uint32_t MACIMR;
-  __IOM uint32_t MACA0HR;
-  __IOM uint32_t MACA0LR;
-  __IOM uint32_t MACA1HR;
-  __IOM uint32_t MACA1LR;
-  __IOM uint32_t MACA2HR;
-  __IOM uint32_t MACA2LR;
-  __IOM uint32_t MACA3HR;
-  __IOM uint32_t MACA3LR;               /*   24 */
+  __IO uint32_t MACDBGR;
+  __IO uint32_t MACSR;                 /*   15 */
+  __IO uint32_t MACIMR;
+  __IO uint32_t MACA0HR;
+  __IO uint32_t MACA0LR;
+  __IO uint32_t MACA1HR;
+  __IO uint32_t MACA1LR;
+  __IO uint32_t MACA2HR;
+  __IO uint32_t MACA2LR;
+  __IO uint32_t MACA3HR;
+  __IO uint32_t MACA3LR;               /*   24 */
   uint32_t      RESERVED2[40];
-  __IOM uint32_t MMCCR;                 /*   65 */
-  __IOM uint32_t MMCRIR;
-  __IOM uint32_t MMCTIR;
-  __IOM uint32_t MMCRIMR;
-  __IOM uint32_t MMCTIMR;               /*   69 */
+  __IO uint32_t MMCCR;                 /*   65 */
+  __IO uint32_t MMCRIR;
+  __IO uint32_t MMCTIR;
+  __IO uint32_t MMCRIMR;
+  __IO uint32_t MMCTIMR;               /*   69 */
   uint32_t      RESERVED3[14];
-  __IOM uint32_t MMCTGFSCCR;            /*   84 */
-  __IOM uint32_t MMCTGFMSCCR;
+  __IO uint32_t MMCTGFSCCR;            /*   84 */
+  __IO uint32_t MMCTGFMSCCR;
   uint32_t      RESERVED4[5];
-  __IOM uint32_t MMCTGFCR;
+  __IO uint32_t MMCTGFCR;
   uint32_t      RESERVED5[10];
-  __IOM uint32_t MMCRFCECR;
-  __IOM uint32_t MMCRFAECR;
+  __IO uint32_t MMCRFCECR;
+  __IO uint32_t MMCRFAECR;
   uint32_t      RESERVED6[10];
-  __IOM uint32_t MMCRGUFCR;
+  __IO uint32_t MMCRGUFCR;
   uint32_t      RESERVED7[334];
-  __IOM uint32_t PTPTSCR;
-  __IOM uint32_t PTPSSIR;
-  __IOM uint32_t PTPTSHR;
-  __IOM uint32_t PTPTSLR;
-  __IOM uint32_t PTPTSHUR;
-  __IOM uint32_t PTPTSLUR;
-  __IOM uint32_t PTPTSAR;
-  __IOM uint32_t PTPTTHR;
-  __IOM uint32_t PTPTTLR;
-  __IOM uint32_t RESERVED8;
-  __IOM uint32_t PTPTSSR;
+  __IO uint32_t PTPTSCR;
+  __IO uint32_t PTPSSIR;
+  __IO uint32_t PTPTSHR;
+  __IO uint32_t PTPTSLR;
+  __IO uint32_t PTPTSHUR;
+  __IO uint32_t PTPTSLUR;
+  __IO uint32_t PTPTSAR;
+  __IO uint32_t PTPTTHR;
+  __IO uint32_t PTPTTLR;
+  __IO uint32_t RESERVED8;
+  __IO uint32_t PTPTSSR;
   uint32_t      RESERVED9[565];
-  __IOM uint32_t DMABMR;
-  __IOM uint32_t DMATPDR;
-  __IOM uint32_t DMARPDR;
-  __IOM uint32_t DMARDLAR;
-  __IOM uint32_t DMATDLAR;
-  __IOM uint32_t DMASR;
-  __IOM uint32_t DMAOMR;
-  __IOM uint32_t DMAIER;
-  __IOM uint32_t DMAMFBOCR;
-  __IOM uint32_t DMARSWTR;
+  __IO uint32_t DMABMR;
+  __IO uint32_t DMATPDR;
+  __IO uint32_t DMARPDR;
+  __IO uint32_t DMARDLAR;
+  __IO uint32_t DMATDLAR;
+  __IO uint32_t DMASR;
+  __IO uint32_t DMAOMR;
+  __IO uint32_t DMAIER;
+  __IO uint32_t DMAMFBOCR;
+  __IO uint32_t DMARSWTR;
   uint32_t      RESERVED10[8];
-  __IOM uint32_t DMACHTDR;
-  __IOM uint32_t DMACHRDR;
-  __IOM uint32_t DMACHTBAR;
-  __IOM uint32_t DMACHRBAR;
+  __IO uint32_t DMACHTDR;
+  __IO uint32_t DMACHRDR;
+  __IO uint32_t DMACHTBAR;
+  __IO uint32_t DMACHRBAR;
 } ETH_TypeDef;
 
 /** 
@@ -563,12 +563,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -577,13 +577,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -592,7 +592,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
 } FMC_Bank1_TypeDef; 
 
 /** 
@@ -601,7 +601,7 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FMC_Bank1E_TypeDef;
 
 /** 
@@ -610,12 +610,12 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t PCR;       /*!< NAND Flash control register,                       Address offset: 0x80 */
-  __IOM uint32_t SR;        /*!< NAND Flash FIFO status and interrupt register,     Address offset: 0x84 */
-  __IOM uint32_t PMEM;      /*!< NAND Flash Common memory space timing register,    Address offset: 0x88 */
-  __IOM uint32_t PATT;      /*!< NAND Flash Attribute memory space timing register, Address offset: 0x8C */
+  __IO uint32_t PCR;       /*!< NAND Flash control register,                       Address offset: 0x80 */
+  __IO uint32_t SR;        /*!< NAND Flash FIFO status and interrupt register,     Address offset: 0x84 */
+  __IO uint32_t PMEM;      /*!< NAND Flash Common memory space timing register,    Address offset: 0x88 */
+  __IO uint32_t PATT;      /*!< NAND Flash Attribute memory space timing register, Address offset: 0x8C */
   uint32_t      RESERVED;  /*!< Reserved, 0x90                                                          */
-  __IOM uint32_t ECCR;      /*!< NAND Flash ECC result registers,                   Address offset: 0x94 */
+  __IO uint32_t ECCR;      /*!< NAND Flash ECC result registers,                   Address offset: 0x94 */
 } FMC_Bank3_TypeDef;
 
 /** 
@@ -624,11 +624,11 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
-  __IOM uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
-  __IOM uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
-  __IOM uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
-  __IOM uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
+  __IO uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
+  __IO uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
+  __IO uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
+  __IO uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
+  __IO uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
 } FMC_Bank5_6_TypeDef;
 
 /** 
@@ -637,15 +637,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -654,11 +654,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -667,16 +667,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /** 
@@ -685,10 +685,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 /** 
@@ -698,22 +698,22 @@ typedef struct
 typedef struct
 {
   uint32_t      RESERVED0[2];  /*!< Reserved, 0x00-0x04                                                       */
-  __IOM uint32_t SSCR;          /*!< LTDC Synchronization Size Configuration Register,    Address offset: 0x08 */
-  __IOM uint32_t BPCR;          /*!< LTDC Back Porch Configuration Register,              Address offset: 0x0C */
-  __IOM uint32_t AWCR;          /*!< LTDC Active Width Configuration Register,            Address offset: 0x10 */
-  __IOM uint32_t TWCR;          /*!< LTDC Total Width Configuration Register,             Address offset: 0x14 */
-  __IOM uint32_t GCR;           /*!< LTDC Global Control Register,                        Address offset: 0x18 */
+  __IO uint32_t SSCR;          /*!< LTDC Synchronization Size Configuration Register,    Address offset: 0x08 */
+  __IO uint32_t BPCR;          /*!< LTDC Back Porch Configuration Register,              Address offset: 0x0C */
+  __IO uint32_t AWCR;          /*!< LTDC Active Width Configuration Register,            Address offset: 0x10 */
+  __IO uint32_t TWCR;          /*!< LTDC Total Width Configuration Register,             Address offset: 0x14 */
+  __IO uint32_t GCR;           /*!< LTDC Global Control Register,                        Address offset: 0x18 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x1C-0x20                                                       */
-  __IOM uint32_t SRCR;          /*!< LTDC Shadow Reload Configuration Register,           Address offset: 0x24 */
+  __IO uint32_t SRCR;          /*!< LTDC Shadow Reload Configuration Register,           Address offset: 0x24 */
   uint32_t      RESERVED2[1];  /*!< Reserved, 0x28                                                            */
-  __IOM uint32_t BCCR;          /*!< LTDC Background Color Configuration Register,        Address offset: 0x2C */
+  __IO uint32_t BCCR;          /*!< LTDC Background Color Configuration Register,        Address offset: 0x2C */
   uint32_t      RESERVED3[1];  /*!< Reserved, 0x30                                                            */
-  __IOM uint32_t IER;           /*!< LTDC Interrupt Enable Register,                      Address offset: 0x34 */
-  __IOM uint32_t ISR;           /*!< LTDC Interrupt Status Register,                      Address offset: 0x38 */
-  __IOM uint32_t ICR;           /*!< LTDC Interrupt Clear Register,                       Address offset: 0x3C */
-  __IOM uint32_t LIPCR;         /*!< LTDC Line Interrupt Position Configuration Register, Address offset: 0x40 */
-  __IOM uint32_t CPSR;          /*!< LTDC Current Position Status Register,               Address offset: 0x44 */
-  __IOM uint32_t CDSR;          /*!< LTDC Current Display Status Register,                Address offset: 0x48 */
+  __IO uint32_t IER;           /*!< LTDC Interrupt Enable Register,                      Address offset: 0x34 */
+  __IO uint32_t ISR;           /*!< LTDC Interrupt Status Register,                      Address offset: 0x38 */
+  __IO uint32_t ICR;           /*!< LTDC Interrupt Clear Register,                       Address offset: 0x3C */
+  __IO uint32_t LIPCR;         /*!< LTDC Line Interrupt Position Configuration Register, Address offset: 0x40 */
+  __IO uint32_t CPSR;          /*!< LTDC Current Position Status Register,               Address offset: 0x44 */
+  __IO uint32_t CDSR;          /*!< LTDC Current Display Status Register,                Address offset: 0x48 */
 } LTDC_TypeDef;
 
 /** 
@@ -722,20 +722,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< LTDC Layerx Control Register                                  Address offset: 0x84 */
-  __IOM uint32_t WHPCR;         /*!< LTDC Layerx Window Horizontal Position Configuration Register Address offset: 0x88 */
-  __IOM uint32_t WVPCR;         /*!< LTDC Layerx Window Vertical Position Configuration Register   Address offset: 0x8C */
-  __IOM uint32_t CKCR;          /*!< LTDC Layerx Color Keying Configuration Register               Address offset: 0x90 */
-  __IOM uint32_t PFCR;          /*!< LTDC Layerx Pixel Format Configuration Register               Address offset: 0x94 */
-  __IOM uint32_t CACR;          /*!< LTDC Layerx Constant Alpha Configuration Register             Address offset: 0x98 */
-  __IOM uint32_t DCCR;          /*!< LTDC Layerx Default Color Configuration Register              Address offset: 0x9C */
-  __IOM uint32_t BFCR;          /*!< LTDC Layerx Blending Factors Configuration Register           Address offset: 0xA0 */
+  __IO uint32_t CR;            /*!< LTDC Layerx Control Register                                  Address offset: 0x84 */
+  __IO uint32_t WHPCR;         /*!< LTDC Layerx Window Horizontal Position Configuration Register Address offset: 0x88 */
+  __IO uint32_t WVPCR;         /*!< LTDC Layerx Window Vertical Position Configuration Register   Address offset: 0x8C */
+  __IO uint32_t CKCR;          /*!< LTDC Layerx Color Keying Configuration Register               Address offset: 0x90 */
+  __IO uint32_t PFCR;          /*!< LTDC Layerx Pixel Format Configuration Register               Address offset: 0x94 */
+  __IO uint32_t CACR;          /*!< LTDC Layerx Constant Alpha Configuration Register             Address offset: 0x98 */
+  __IO uint32_t DCCR;          /*!< LTDC Layerx Default Color Configuration Register              Address offset: 0x9C */
+  __IO uint32_t BFCR;          /*!< LTDC Layerx Blending Factors Configuration Register           Address offset: 0xA0 */
   uint32_t      RESERVED0[2];  /*!< Reserved                                                                           */
-  __IOM uint32_t CFBAR;         /*!< LTDC Layerx Color Frame Buffer Address Register               Address offset: 0xAC */
-  __IOM uint32_t CFBLR;         /*!< LTDC Layerx Color Frame Buffer Length Register                Address offset: 0xB0 */
-  __IOM uint32_t CFBLNR;        /*!< LTDC Layerx ColorFrame Buffer Line Number Register            Address offset: 0xB4 */
+  __IO uint32_t CFBAR;         /*!< LTDC Layerx Color Frame Buffer Address Register               Address offset: 0xAC */
+  __IO uint32_t CFBLR;         /*!< LTDC Layerx Color Frame Buffer Length Register                Address offset: 0xB0 */
+  __IO uint32_t CFBLNR;        /*!< LTDC Layerx ColorFrame Buffer Line Number Register            Address offset: 0xB4 */
   uint32_t      RESERVED1[3];  /*!< Reserved                                                                           */
-  __IOM uint32_t CLUTWR;        /*!< LTDC Layerx CLUT Write Register                               Address offset: 0x144*/
+  __IO uint32_t CLUTWR;        /*!< LTDC Layerx CLUT Write Register                               Address offset: 0x144*/
 } LTDC_Layer_TypeDef;
 
 /** 
@@ -744,8 +744,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -754,38 +754,38 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
-  __IOM uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
 } RCC_TypeDef;
 
 /** 
@@ -794,46 +794,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -842,19 +842,19 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
+  __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
 } SAI_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
-  __IOM uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
-  __IOM uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
-  __IOM uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
-  __IOM uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
-  __IOM uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
-  __IOM uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
+  __IO uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
+  __IO uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
+  __IO uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
+  __IO uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
+  __IO uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
+  __IO uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
+  __IO uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
 } SAI_Block_TypeDef;
 
 /** 
@@ -863,26 +863,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -891,15 +891,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 /** 
@@ -908,19 +908,19 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
-  __IOM uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
-  __IOM uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
-  __IOM uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
-  __IOM uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
-  __IOM uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
-  __IOM uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
-  __IOM uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
-  __IOM uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
-  __IOM uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
-  __IOM uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
-  __IOM uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
+  __IO uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
+  __IO uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
+  __IO uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
+  __IO uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
+  __IO uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
+  __IO uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
+  __IO uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
+  __IO uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
+  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
+  __IO uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
+  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
 } QUADSPI_TypeDef;
 
 /** 
@@ -929,27 +929,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -958,13 +958,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -973,9 +973,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -984,9 +984,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -994,30 +994,30 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved5[3];             /*!< Reserved                                040h-048h */
-  __IOM uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
+  __IO uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
   uint32_t  Reserved6;                /*!< Reserved                                     050h */
-  __IOM uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
+  __IO uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
   uint32_t  Reserved;                 /*!< Reserved                                     058h */
-  __IOM uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
+  __IO uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
   uint32_t  Reserved43[40];           /*!< Reserved                                058h-0FFh */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -1025,26 +1025,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -1052,13 +1052,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -1067,12 +1067,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -1081,13 +1081,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -1095,12 +1095,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 

--- a/Include/stm32f479xx.h
+++ b/Include/stm32f479xx.h
@@ -188,33 +188,33 @@ typedef enum
 
 typedef struct
 {
-  __IOM uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
-  __IOM uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
-  __IOM uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
-  __IOM uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
-  __IOM uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
-  __IOM uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
-  __IOM uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
-  __IOM uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
-  __IOM uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
-  __IOM uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
-  __IOM uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
-  __IOM uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
-  __IOM uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
-  __IOM uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
-  __IOM uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
-  __IOM uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
-  __IOM uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
-  __IOM uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
-  __IOM uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
-  __IOM uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
+  __IO uint32_t SR;     /*!< ADC status register,                         Address offset: 0x00 */
+  __IO uint32_t CR1;    /*!< ADC control register 1,                      Address offset: 0x04 */
+  __IO uint32_t CR2;    /*!< ADC control register 2,                      Address offset: 0x08 */
+  __IO uint32_t SMPR1;  /*!< ADC sample time register 1,                  Address offset: 0x0C */
+  __IO uint32_t SMPR2;  /*!< ADC sample time register 2,                  Address offset: 0x10 */
+  __IO uint32_t JOFR1;  /*!< ADC injected channel data offset register 1, Address offset: 0x14 */
+  __IO uint32_t JOFR2;  /*!< ADC injected channel data offset register 2, Address offset: 0x18 */
+  __IO uint32_t JOFR3;  /*!< ADC injected channel data offset register 3, Address offset: 0x1C */
+  __IO uint32_t JOFR4;  /*!< ADC injected channel data offset register 4, Address offset: 0x20 */
+  __IO uint32_t HTR;    /*!< ADC watchdog higher threshold register,      Address offset: 0x24 */
+  __IO uint32_t LTR;    /*!< ADC watchdog lower threshold register,       Address offset: 0x28 */
+  __IO uint32_t SQR1;   /*!< ADC regular sequence register 1,             Address offset: 0x2C */
+  __IO uint32_t SQR2;   /*!< ADC regular sequence register 2,             Address offset: 0x30 */
+  __IO uint32_t SQR3;   /*!< ADC regular sequence register 3,             Address offset: 0x34 */
+  __IO uint32_t JSQR;   /*!< ADC injected sequence register,              Address offset: 0x38*/
+  __IO uint32_t JDR1;   /*!< ADC injected data register 1,                Address offset: 0x3C */
+  __IO uint32_t JDR2;   /*!< ADC injected data register 2,                Address offset: 0x40 */
+  __IO uint32_t JDR3;   /*!< ADC injected data register 3,                Address offset: 0x44 */
+  __IO uint32_t JDR4;   /*!< ADC injected data register 4,                Address offset: 0x48 */
+  __IO uint32_t DR;     /*!< ADC regular data register,                   Address offset: 0x4C */
 } ADC_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
-  __IOM uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
-  __IOM uint32_t CDR;    /*!< ADC common regular data register for dual
+  __IO uint32_t CSR;    /*!< ADC Common status register,                  Address offset: ADC1 base address + 0x300 */
+  __IO uint32_t CCR;    /*!< ADC common control register,                 Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CDR;    /*!< ADC common regular data register for dual
                              AND triple modes,                            Address offset: ADC1 base address + 0x308 */
 } ADC_Common_TypeDef;
 
@@ -225,10 +225,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TIR;  /*!< CAN TX mailbox identifier register */
-  __IOM uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
-  __IOM uint32_t TDLR; /*!< CAN mailbox data low register */
-  __IOM uint32_t TDHR; /*!< CAN mailbox data high register */
+  __IO uint32_t TIR;  /*!< CAN TX mailbox identifier register */
+  __IO uint32_t TDTR; /*!< CAN mailbox data length control and time stamp register */
+  __IO uint32_t TDLR; /*!< CAN mailbox data low register */
+  __IO uint32_t TDHR; /*!< CAN mailbox data high register */
 } CAN_TxMailBox_TypeDef;
 
 /** 
@@ -237,10 +237,10 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
-  __IOM uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
-  __IOM uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
-  __IOM uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
+  __IO uint32_t RIR;  /*!< CAN receive FIFO mailbox identifier register */
+  __IO uint32_t RDTR; /*!< CAN receive FIFO mailbox data length control and time stamp register */
+  __IO uint32_t RDLR; /*!< CAN receive FIFO mailbox data low register */
+  __IO uint32_t RDHR; /*!< CAN receive FIFO mailbox data high register */
 } CAN_FIFOMailBox_TypeDef;
 
 /** 
@@ -249,8 +249,8 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t FR1; /*!< CAN Filter bank register 1 */
-  __IOM uint32_t FR2; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR1; /*!< CAN Filter bank register 1 */
+  __IO uint32_t FR2; /*!< CAN Filter bank register 1 */
 } CAN_FilterRegister_TypeDef;
 
 /** 
@@ -259,26 +259,26 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
-  __IOM uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
-  __IOM uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
-  __IOM uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
-  __IOM uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
-  __IOM uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
-  __IOM uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
-  __IOM uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
+  __IO uint32_t              MCR;                 /*!< CAN master control register,         Address offset: 0x00          */
+  __IO uint32_t              MSR;                 /*!< CAN master status register,          Address offset: 0x04          */
+  __IO uint32_t              TSR;                 /*!< CAN transmit status register,        Address offset: 0x08          */
+  __IO uint32_t              RF0R;                /*!< CAN receive FIFO 0 register,         Address offset: 0x0C          */
+  __IO uint32_t              RF1R;                /*!< CAN receive FIFO 1 register,         Address offset: 0x10          */
+  __IO uint32_t              IER;                 /*!< CAN interrupt enable register,       Address offset: 0x14          */
+  __IO uint32_t              ESR;                 /*!< CAN error status register,           Address offset: 0x18          */
+  __IO uint32_t              BTR;                 /*!< CAN bit timing register,             Address offset: 0x1C          */
   uint32_t                   RESERVED0[88];       /*!< Reserved, 0x020 - 0x17F                                            */
   CAN_TxMailBox_TypeDef      sTxMailBox[3];       /*!< CAN Tx MailBox,                      Address offset: 0x180 - 0x1AC */
   CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];     /*!< CAN FIFO MailBox,                    Address offset: 0x1B0 - 0x1CC */
   uint32_t                   RESERVED1[12];       /*!< Reserved, 0x1D0 - 0x1FF                                            */
-  __IOM uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
-  __IOM uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
+  __IO uint32_t              FMR;                 /*!< CAN filter master register,          Address offset: 0x200         */
+  __IO uint32_t              FM1R;                /*!< CAN filter mode register,            Address offset: 0x204         */
   uint32_t                   RESERVED2;           /*!< Reserved, 0x208                                                    */
-  __IOM uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
+  __IO uint32_t              FS1R;                /*!< CAN filter scale register,           Address offset: 0x20C         */
   uint32_t                   RESERVED3;           /*!< Reserved, 0x210                                                    */
-  __IOM uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
+  __IO uint32_t              FFA1R;               /*!< CAN filter FIFO assignment register, Address offset: 0x214         */
   uint32_t                   RESERVED4;           /*!< Reserved, 0x218                                                    */
-  __IOM uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
+  __IO uint32_t              FA1R;                /*!< CAN filter activation register,      Address offset: 0x21C         */
   uint32_t                   RESERVED5[8];        /*!< Reserved, 0x220-0x23F                                              */ 
   CAN_FilterRegister_TypeDef sFilterRegister[28]; /*!< CAN Filter Register,                 Address offset: 0x240-0x31C   */
 } CAN_TypeDef;
@@ -289,11 +289,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
-  __IOM uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
+  __IO uint32_t DR;         /*!< CRC Data register,             Address offset: 0x00 */
+  __IO uint8_t  IDR;        /*!< CRC Independent data register, Address offset: 0x04 */
   uint8_t       RESERVED0;  /*!< Reserved, 0x05                                      */
   uint16_t      RESERVED1;  /*!< Reserved, 0x06                                      */
-  __IOM uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
+  __IO uint32_t CR;         /*!< CRC Control register,          Address offset: 0x08 */
 } CRC_TypeDef;
 
 /** 
@@ -302,20 +302,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
-  __IOM uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
-  __IOM uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
-  __IOM uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
-  __IOM uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
-  __IOM uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
-  __IOM uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
-  __IOM uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
-  __IOM uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
-  __IOM uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
-  __IOM uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
-  __IOM uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
-  __IOM uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CR;       /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;  /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;  /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;  /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;   /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;  /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;  /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;   /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;  /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;  /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;   /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;     /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;     /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;       /*!< DAC status register,                                     Address offset: 0x34 */
 } DAC_TypeDef;
 
 /** 
@@ -324,10 +324,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
-  __IOM uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
-  __IOM uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
-  __IOM uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
+  __IO uint32_t IDCODE;  /*!< MCU device ID code,               Address offset: 0x00 */
+  __IO uint32_t CR;      /*!< Debug MCU configuration register, Address offset: 0x04 */
+  __IO uint32_t APB1FZ;  /*!< Debug MCU APB1 freeze register,   Address offset: 0x08 */
+  __IO uint32_t APB2FZ;  /*!< Debug MCU APB2 freeze register,   Address offset: 0x0C */
 }DBGMCU_TypeDef;
 
 /** 
@@ -336,17 +336,17 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
-  __IOM uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
-  __IOM uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
-  __IOM uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
-  __IOM uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
-  __IOM uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
-  __IOM uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
-  __IOM uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
-  __IOM uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
-  __IOM uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
-  __IOM uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
+  __IO uint32_t CR;       /*!< DCMI control register 1,                       Address offset: 0x00 */
+  __IO uint32_t SR;       /*!< DCMI status register,                          Address offset: 0x04 */
+  __IO uint32_t RISR;     /*!< DCMI raw interrupt status register,            Address offset: 0x08 */
+  __IO uint32_t IER;      /*!< DCMI interrupt enable register,                Address offset: 0x0C */
+  __IO uint32_t MISR;     /*!< DCMI masked interrupt status register,         Address offset: 0x10 */
+  __IO uint32_t ICR;      /*!< DCMI interrupt clear register,                 Address offset: 0x14 */
+  __IO uint32_t ESCR;     /*!< DCMI embedded synchronization code register,   Address offset: 0x18 */
+  __IO uint32_t ESUR;     /*!< DCMI embedded synchronization unmask register, Address offset: 0x1C */
+  __IO uint32_t CWSTRTR;  /*!< DCMI crop window start,                        Address offset: 0x20 */
+  __IO uint32_t CWSIZER;  /*!< DCMI crop window size,                         Address offset: 0x24 */
+  __IO uint32_t DR;       /*!< DCMI data register,                            Address offset: 0x28 */
 } DCMI_TypeDef;
 
 /** 
@@ -355,20 +355,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;     /*!< DMA stream x configuration register      */
-  __IOM uint32_t NDTR;   /*!< DMA stream x number of data register     */
-  __IOM uint32_t PAR;    /*!< DMA stream x peripheral address register */
-  __IOM uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
-  __IOM uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
-  __IOM uint32_t FCR;    /*!< DMA stream x FIFO control register       */
+  __IO uint32_t CR;     /*!< DMA stream x configuration register      */
+  __IO uint32_t NDTR;   /*!< DMA stream x number of data register     */
+  __IO uint32_t PAR;    /*!< DMA stream x peripheral address register */
+  __IO uint32_t M0AR;   /*!< DMA stream x memory 0 address register   */
+  __IO uint32_t M1AR;   /*!< DMA stream x memory 1 address register   */
+  __IO uint32_t FCR;    /*!< DMA stream x FIFO control register       */
 } DMA_Stream_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IOM uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IOM uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IOM uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
+  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
+  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
+  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
 } DMA_TypeDef;
 
 /** 
@@ -377,29 +377,29 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
-  __IOM uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
-  __IOM uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
-  __IOM uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
-  __IOM uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
-  __IOM uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
-  __IOM uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
-  __IOM uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
-  __IOM uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
-  __IOM uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
-  __IOM uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
-  __IOM uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
-  __IOM uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
-  __IOM uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
-  __IOM uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
-  __IOM uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
-  __IOM uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
-  __IOM uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
-  __IOM uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
-  __IOM uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
+  __IO uint32_t CR;            /*!< DMA2D Control Register,                         Address offset: 0x00 */
+  __IO uint32_t ISR;           /*!< DMA2D Interrupt Status Register,                Address offset: 0x04 */
+  __IO uint32_t IFCR;          /*!< DMA2D Interrupt Flag Clear Register,            Address offset: 0x08 */
+  __IO uint32_t FGMAR;         /*!< DMA2D Foreground Memory Address Register,       Address offset: 0x0C */
+  __IO uint32_t FGOR;          /*!< DMA2D Foreground Offset Register,               Address offset: 0x10 */
+  __IO uint32_t BGMAR;         /*!< DMA2D Background Memory Address Register,       Address offset: 0x14 */
+  __IO uint32_t BGOR;          /*!< DMA2D Background Offset Register,               Address offset: 0x18 */
+  __IO uint32_t FGPFCCR;       /*!< DMA2D Foreground PFC Control Register,          Address offset: 0x1C */
+  __IO uint32_t FGCOLR;        /*!< DMA2D Foreground Color Register,                Address offset: 0x20 */
+  __IO uint32_t BGPFCCR;       /*!< DMA2D Background PFC Control Register,          Address offset: 0x24 */
+  __IO uint32_t BGCOLR;        /*!< DMA2D Background Color Register,                Address offset: 0x28 */
+  __IO uint32_t FGCMAR;        /*!< DMA2D Foreground CLUT Memory Address Register,  Address offset: 0x2C */
+  __IO uint32_t BGCMAR;        /*!< DMA2D Background CLUT Memory Address Register,  Address offset: 0x30 */
+  __IO uint32_t OPFCCR;        /*!< DMA2D Output PFC Control Register,              Address offset: 0x34 */
+  __IO uint32_t OCOLR;         /*!< DMA2D Output Color Register,                    Address offset: 0x38 */
+  __IO uint32_t OMAR;          /*!< DMA2D Output Memory Address Register,           Address offset: 0x3C */
+  __IO uint32_t OOR;           /*!< DMA2D Output Offset Register,                   Address offset: 0x40 */
+  __IO uint32_t NLR;           /*!< DMA2D Number of Line Register,                  Address offset: 0x44 */
+  __IO uint32_t LWR;           /*!< DMA2D Line Watermark Register,                  Address offset: 0x48 */
+  __IO uint32_t AMTCR;         /*!< DMA2D AHB Master Timer Configuration Register,  Address offset: 0x4C */
   uint32_t      RESERVED[236]; /*!< Reserved, 0x50-0x3FF */
-  __IOM uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
-  __IOM uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
+  __IO uint32_t FGCLUT[256];   /*!< DMA2D Foreground CLUT,                          Address offset:400-7FF */
+  __IO uint32_t BGCLUT[256];   /*!< DMA2D Background CLUT,                          Address offset:800-BFF */
 } DMA2D_TypeDef;
 
 /** 
@@ -408,79 +408,79 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t VR;            /*!< DSI Host Version Register,                                 Address offset: 0x00        */
-  __IOM uint32_t CR;            /*!< DSI Host Control Register,                                 Address offset: 0x04        */
-  __IOM uint32_t CCR;           /*!< DSI HOST Clock Control Register,                           Address offset: 0x08        */
-  __IOM uint32_t LVCIDR;        /*!< DSI Host LTDC VCID Register,                               Address offset: 0x0C        */
-  __IOM uint32_t LCOLCR;        /*!< DSI Host LTDC Color Coding Register,                       Address offset: 0x10        */
-  __IOM uint32_t LPCR;          /*!< DSI Host LTDC Polarity Configuration Register,             Address offset: 0x14        */
-  __IOM uint32_t LPMCR;         /*!< DSI Host Low-Power Mode Configuration Register,            Address offset: 0x18        */
+  __IO uint32_t VR;            /*!< DSI Host Version Register,                                 Address offset: 0x00        */
+  __IO uint32_t CR;            /*!< DSI Host Control Register,                                 Address offset: 0x04        */
+  __IO uint32_t CCR;           /*!< DSI HOST Clock Control Register,                           Address offset: 0x08        */
+  __IO uint32_t LVCIDR;        /*!< DSI Host LTDC VCID Register,                               Address offset: 0x0C        */
+  __IO uint32_t LCOLCR;        /*!< DSI Host LTDC Color Coding Register,                       Address offset: 0x10        */
+  __IO uint32_t LPCR;          /*!< DSI Host LTDC Polarity Configuration Register,             Address offset: 0x14        */
+  __IO uint32_t LPMCR;         /*!< DSI Host Low-Power Mode Configuration Register,            Address offset: 0x18        */
   uint32_t      RESERVED0[4];  /*!< Reserved, 0x1C - 0x2B                                                                  */
-  __IOM uint32_t PCR;           /*!< DSI Host Protocol Configuration Register,                  Address offset: 0x2C        */
-  __IOM uint32_t GVCIDR;        /*!< DSI Host Generic VCID Register,                            Address offset: 0x30        */
-  __IOM uint32_t MCR;           /*!< DSI Host Mode Configuration Register,                      Address offset: 0x34        */
-  __IOM uint32_t VMCR;          /*!< DSI Host Video Mode Configuration Register,                Address offset: 0x38        */
-  __IOM uint32_t VPCR;          /*!< DSI Host Video Packet Configuration Register,              Address offset: 0x3C        */
-  __IOM uint32_t VCCR;          /*!< DSI Host Video Chunks Configuration Register,              Address offset: 0x40        */
-  __IOM uint32_t VNPCR;         /*!< DSI Host Video Null Packet Configuration Register,         Address offset: 0x44        */
-  __IOM uint32_t VHSACR;        /*!< DSI Host Video HSA Configuration Register,                 Address offset: 0x48        */
-  __IOM uint32_t VHBPCR;        /*!< DSI Host Video HBP Configuration Register,                 Address offset: 0x4C        */
-  __IOM uint32_t VLCR;          /*!< DSI Host Video Line Configuration Register,                Address offset: 0x50        */
-  __IOM uint32_t VVSACR;        /*!< DSI Host Video VSA Configuration Register,                 Address offset: 0x54        */
-  __IOM uint32_t VVBPCR;        /*!< DSI Host Video VBP Configuration Register,                 Address offset: 0x58        */
-  __IOM uint32_t VVFPCR;        /*!< DSI Host Video VFP Configuration Register,                 Address offset: 0x5C        */
-  __IOM uint32_t VVACR;         /*!< DSI Host Video VA Configuration Register,                  Address offset: 0x60        */
-  __IOM uint32_t LCCR;          /*!< DSI Host LTDC Command Configuration Register,              Address offset: 0x64        */
-  __IOM uint32_t CMCR;          /*!< DSI Host Command Mode Configuration Register,              Address offset: 0x68        */
-  __IOM uint32_t GHCR;          /*!< DSI Host Generic Header Configuration Register,            Address offset: 0x6C        */
-  __IOM uint32_t GPDR;          /*!< DSI Host Generic Payload Data Register,                    Address offset: 0x70        */
-  __IOM uint32_t GPSR;          /*!< DSI Host Generic Packet Status Register,                   Address offset: 0x74        */
-  __IOM uint32_t TCCR[6];       /*!< DSI Host Timeout Counter Configuration Register,           Address offset: 0x78-0x8F   */
-  __IOM uint32_t TDCR;          /*!< DSI Host 3D Configuration Register,                        Address offset: 0x90        */
-  __IOM uint32_t CLCR;          /*!< DSI Host Clock Lane Configuration Register,                Address offset: 0x94        */
-  __IOM uint32_t CLTCR;         /*!< DSI Host Clock Lane Timer Configuration Register,          Address offset: 0x98        */
-  __IOM uint32_t DLTCR;         /*!< DSI Host Data Lane Timer Configuration Register,           Address offset: 0x9C        */
-  __IOM uint32_t PCTLR;         /*!< DSI Host PHY Control Register,                             Address offset: 0xA0        */
-  __IOM uint32_t PCONFR;        /*!< DSI Host PHY Configuration Register,                       Address offset: 0xA4        */
-  __IOM uint32_t PUCR;          /*!< DSI Host PHY ULPS Control Register,                        Address offset: 0xA8        */
-  __IOM uint32_t PTTCR;         /*!< DSI Host PHY TX Triggers Configuration Register,           Address offset: 0xAC        */
-  __IOM uint32_t PSR;           /*!< DSI Host PHY Status Register,                              Address offset: 0xB0        */
+  __IO uint32_t PCR;           /*!< DSI Host Protocol Configuration Register,                  Address offset: 0x2C        */
+  __IO uint32_t GVCIDR;        /*!< DSI Host Generic VCID Register,                            Address offset: 0x30        */
+  __IO uint32_t MCR;           /*!< DSI Host Mode Configuration Register,                      Address offset: 0x34        */
+  __IO uint32_t VMCR;          /*!< DSI Host Video Mode Configuration Register,                Address offset: 0x38        */
+  __IO uint32_t VPCR;          /*!< DSI Host Video Packet Configuration Register,              Address offset: 0x3C        */
+  __IO uint32_t VCCR;          /*!< DSI Host Video Chunks Configuration Register,              Address offset: 0x40        */
+  __IO uint32_t VNPCR;         /*!< DSI Host Video Null Packet Configuration Register,         Address offset: 0x44        */
+  __IO uint32_t VHSACR;        /*!< DSI Host Video HSA Configuration Register,                 Address offset: 0x48        */
+  __IO uint32_t VHBPCR;        /*!< DSI Host Video HBP Configuration Register,                 Address offset: 0x4C        */
+  __IO uint32_t VLCR;          /*!< DSI Host Video Line Configuration Register,                Address offset: 0x50        */
+  __IO uint32_t VVSACR;        /*!< DSI Host Video VSA Configuration Register,                 Address offset: 0x54        */
+  __IO uint32_t VVBPCR;        /*!< DSI Host Video VBP Configuration Register,                 Address offset: 0x58        */
+  __IO uint32_t VVFPCR;        /*!< DSI Host Video VFP Configuration Register,                 Address offset: 0x5C        */
+  __IO uint32_t VVACR;         /*!< DSI Host Video VA Configuration Register,                  Address offset: 0x60        */
+  __IO uint32_t LCCR;          /*!< DSI Host LTDC Command Configuration Register,              Address offset: 0x64        */
+  __IO uint32_t CMCR;          /*!< DSI Host Command Mode Configuration Register,              Address offset: 0x68        */
+  __IO uint32_t GHCR;          /*!< DSI Host Generic Header Configuration Register,            Address offset: 0x6C        */
+  __IO uint32_t GPDR;          /*!< DSI Host Generic Payload Data Register,                    Address offset: 0x70        */
+  __IO uint32_t GPSR;          /*!< DSI Host Generic Packet Status Register,                   Address offset: 0x74        */
+  __IO uint32_t TCCR[6];       /*!< DSI Host Timeout Counter Configuration Register,           Address offset: 0x78-0x8F   */
+  __IO uint32_t TDCR;          /*!< DSI Host 3D Configuration Register,                        Address offset: 0x90        */
+  __IO uint32_t CLCR;          /*!< DSI Host Clock Lane Configuration Register,                Address offset: 0x94        */
+  __IO uint32_t CLTCR;         /*!< DSI Host Clock Lane Timer Configuration Register,          Address offset: 0x98        */
+  __IO uint32_t DLTCR;         /*!< DSI Host Data Lane Timer Configuration Register,           Address offset: 0x9C        */
+  __IO uint32_t PCTLR;         /*!< DSI Host PHY Control Register,                             Address offset: 0xA0        */
+  __IO uint32_t PCONFR;        /*!< DSI Host PHY Configuration Register,                       Address offset: 0xA4        */
+  __IO uint32_t PUCR;          /*!< DSI Host PHY ULPS Control Register,                        Address offset: 0xA8        */
+  __IO uint32_t PTTCR;         /*!< DSI Host PHY TX Triggers Configuration Register,           Address offset: 0xAC        */
+  __IO uint32_t PSR;           /*!< DSI Host PHY Status Register,                              Address offset: 0xB0        */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0xB4 - 0xBB                                                                  */
-  __IOM uint32_t ISR[2];        /*!< DSI Host Interrupt & Status Register,                      Address offset: 0xBC-0xC3   */
-  __IOM uint32_t IER[2];        /*!< DSI Host Interrupt Enable Register,                        Address offset: 0xC4-0xCB   */
+  __IO uint32_t ISR[2];        /*!< DSI Host Interrupt & Status Register,                      Address offset: 0xBC-0xC3   */
+  __IO uint32_t IER[2];        /*!< DSI Host Interrupt Enable Register,                        Address offset: 0xC4-0xCB   */
   uint32_t      RESERVED2[3];  /*!< Reserved, 0xD0 - 0xD7                                                                  */
-  __IOM uint32_t FIR[2];        /*!< DSI Host Force Interrupt Register,                         Address offset: 0xD8-0xDF   */
+  __IO uint32_t FIR[2];        /*!< DSI Host Force Interrupt Register,                         Address offset: 0xD8-0xDF   */
   uint32_t      RESERVED3[8];  /*!< Reserved, 0xE0 - 0xFF                                                                  */
-  __IOM uint32_t VSCR;          /*!< DSI Host Video Shadow Control Register,                    Address offset: 0x100       */
+  __IO uint32_t VSCR;          /*!< DSI Host Video Shadow Control Register,                    Address offset: 0x100       */
   uint32_t      RESERVED4[2];  /*!< Reserved, 0x104 - 0x10B                                                                */
-  __IOM uint32_t LCVCIDR;       /*!< DSI Host LTDC Current VCID Register,                       Address offset: 0x10C       */
-  __IOM uint32_t LCCCR;         /*!< DSI Host LTDC Current Color Coding Register,               Address offset: 0x110       */
+  __IO uint32_t LCVCIDR;       /*!< DSI Host LTDC Current VCID Register,                       Address offset: 0x10C       */
+  __IO uint32_t LCCCR;         /*!< DSI Host LTDC Current Color Coding Register,               Address offset: 0x110       */
   uint32_t      RESERVED5;     /*!< Reserved, 0x114                                                                        */
-  __IOM uint32_t LPMCCR;        /*!< DSI Host Low-power Mode Current Configuration Register,    Address offset: 0x118       */
+  __IO uint32_t LPMCCR;        /*!< DSI Host Low-power Mode Current Configuration Register,    Address offset: 0x118       */
   uint32_t      RESERVED6[7];  /*!< Reserved, 0x11C - 0x137                                                                */
-  __IOM uint32_t VMCCR;         /*!< DSI Host Video Mode Current Configuration Register,        Address offset: 0x138       */
-  __IOM uint32_t VPCCR;         /*!< DSI Host Video Packet Current Configuration Register,      Address offset: 0x13C       */
-  __IOM uint32_t VCCCR;         /*!< DSI Host Video Chuncks Current Configuration Register,     Address offset: 0x140       */
-  __IOM uint32_t VNPCCR;        /*!< DSI Host Video Null Packet Current Configuration Register, Address offset: 0x144       */
-  __IOM uint32_t VHSACCR;       /*!< DSI Host Video HSA Current Configuration Register,         Address offset: 0x148       */
-  __IOM uint32_t VHBPCCR;       /*!< DSI Host Video HBP Current Configuration Register,         Address offset: 0x14C       */
-  __IOM uint32_t VLCCR;         /*!< DSI Host Video Line Current Configuration Register,        Address offset: 0x150       */
-  __IOM uint32_t VVSACCR;       /*!< DSI Host Video VSA Current Configuration Register,         Address offset: 0x154       */
-  __IOM uint32_t VVBPCCR;       /*!< DSI Host Video VBP Current Configuration Register,         Address offset: 0x158       */
-  __IOM uint32_t VVFPCCR;       /*!< DSI Host Video VFP Current Configuration Register,         Address offset: 0x15C       */
-  __IOM uint32_t VVACCR;        /*!< DSI Host Video VA Current Configuration Register,          Address offset: 0x160       */
+  __IO uint32_t VMCCR;         /*!< DSI Host Video Mode Current Configuration Register,        Address offset: 0x138       */
+  __IO uint32_t VPCCR;         /*!< DSI Host Video Packet Current Configuration Register,      Address offset: 0x13C       */
+  __IO uint32_t VCCCR;         /*!< DSI Host Video Chuncks Current Configuration Register,     Address offset: 0x140       */
+  __IO uint32_t VNPCCR;        /*!< DSI Host Video Null Packet Current Configuration Register, Address offset: 0x144       */
+  __IO uint32_t VHSACCR;       /*!< DSI Host Video HSA Current Configuration Register,         Address offset: 0x148       */
+  __IO uint32_t VHBPCCR;       /*!< DSI Host Video HBP Current Configuration Register,         Address offset: 0x14C       */
+  __IO uint32_t VLCCR;         /*!< DSI Host Video Line Current Configuration Register,        Address offset: 0x150       */
+  __IO uint32_t VVSACCR;       /*!< DSI Host Video VSA Current Configuration Register,         Address offset: 0x154       */
+  __IO uint32_t VVBPCCR;       /*!< DSI Host Video VBP Current Configuration Register,         Address offset: 0x158       */
+  __IO uint32_t VVFPCCR;       /*!< DSI Host Video VFP Current Configuration Register,         Address offset: 0x15C       */
+  __IO uint32_t VVACCR;        /*!< DSI Host Video VA Current Configuration Register,          Address offset: 0x160       */
   uint32_t      RESERVED7[11]; /*!< Reserved, 0x164 - 0x18F                                                                */
-  __IOM uint32_t TDCCR;         /*!< DSI Host 3D Current Configuration Register,                Address offset: 0x190       */
+  __IO uint32_t TDCCR;         /*!< DSI Host 3D Current Configuration Register,                Address offset: 0x190       */
   uint32_t      RESERVED8[155]; /*!< Reserved, 0x194 - 0x3FF                                                               */
-  __IOM uint32_t WCFGR;          /*!< DSI Wrapper Configuration Register,                       Address offset: 0x400       */
-  __IOM uint32_t WCR;            /*!< DSI Wrapper Control Register,                             Address offset: 0x404       */
-  __IOM uint32_t WIER;           /*!< DSI Wrapper Interrupt Enable Register,                    Address offset: 0x408       */
-  __IOM uint32_t WISR;           /*!< DSI Wrapper Interrupt and Status Register,                Address offset: 0x40C       */
-  __IOM uint32_t WIFCR;          /*!< DSI Wrapper Interrupt Flag Clear Register,                Address offset: 0x410       */
+  __IO uint32_t WCFGR;          /*!< DSI Wrapper Configuration Register,                       Address offset: 0x400       */
+  __IO uint32_t WCR;            /*!< DSI Wrapper Control Register,                             Address offset: 0x404       */
+  __IO uint32_t WIER;           /*!< DSI Wrapper Interrupt Enable Register,                    Address offset: 0x408       */
+  __IO uint32_t WISR;           /*!< DSI Wrapper Interrupt and Status Register,                Address offset: 0x40C       */
+  __IO uint32_t WIFCR;          /*!< DSI Wrapper Interrupt Flag Clear Register,                Address offset: 0x410       */
   uint32_t      RESERVED9;      /*!< Reserved, 0x414                                                                       */
-  __IOM uint32_t WPCR[5];        /*!< DSI Wrapper PHY Configuration Register,                   Address offset: 0x418-0x42B */
+  __IO uint32_t WPCR[5];        /*!< DSI Wrapper PHY Configuration Register,                   Address offset: 0x418-0x42B */
   uint32_t      RESERVED10;     /*!< Reserved, 0x42C                                                                       */
-  __IOM uint32_t WRPCR;          /*!< DSI Wrapper Regulator and PLL Control Register, Address offset: 0x430                 */
+  __IO uint32_t WRPCR;          /*!< DSI Wrapper Regulator and PLL Control Register, Address offset: 0x430                 */
 } DSI_TypeDef;
 
 /** 
@@ -489,73 +489,73 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MACCR;
-  __IOM uint32_t MACFFR;
-  __IOM uint32_t MACHTHR;
-  __IOM uint32_t MACHTLR;
-  __IOM uint32_t MACMIIAR;
-  __IOM uint32_t MACMIIDR;
-  __IOM uint32_t MACFCR;
-  __IOM uint32_t MACVLANTR;             /*    8 */
+  __IO uint32_t MACCR;
+  __IO uint32_t MACFFR;
+  __IO uint32_t MACHTHR;
+  __IO uint32_t MACHTLR;
+  __IO uint32_t MACMIIAR;
+  __IO uint32_t MACMIIDR;
+  __IO uint32_t MACFCR;
+  __IO uint32_t MACVLANTR;             /*    8 */
   uint32_t      RESERVED0[2];
-  __IOM uint32_t MACRWUFFR;             /*   11 */
-  __IOM uint32_t MACPMTCSR;
+  __IO uint32_t MACRWUFFR;             /*   11 */
+  __IO uint32_t MACPMTCSR;
   uint32_t      RESERVED1;
-  __IOM uint32_t MACDBGR;
-  __IOM uint32_t MACSR;                 /*   15 */
-  __IOM uint32_t MACIMR;
-  __IOM uint32_t MACA0HR;
-  __IOM uint32_t MACA0LR;
-  __IOM uint32_t MACA1HR;
-  __IOM uint32_t MACA1LR;
-  __IOM uint32_t MACA2HR;
-  __IOM uint32_t MACA2LR;
-  __IOM uint32_t MACA3HR;
-  __IOM uint32_t MACA3LR;               /*   24 */
+  __IO uint32_t MACDBGR;
+  __IO uint32_t MACSR;                 /*   15 */
+  __IO uint32_t MACIMR;
+  __IO uint32_t MACA0HR;
+  __IO uint32_t MACA0LR;
+  __IO uint32_t MACA1HR;
+  __IO uint32_t MACA1LR;
+  __IO uint32_t MACA2HR;
+  __IO uint32_t MACA2LR;
+  __IO uint32_t MACA3HR;
+  __IO uint32_t MACA3LR;               /*   24 */
   uint32_t      RESERVED2[40];
-  __IOM uint32_t MMCCR;                 /*   65 */
-  __IOM uint32_t MMCRIR;
-  __IOM uint32_t MMCTIR;
-  __IOM uint32_t MMCRIMR;
-  __IOM uint32_t MMCTIMR;               /*   69 */
+  __IO uint32_t MMCCR;                 /*   65 */
+  __IO uint32_t MMCRIR;
+  __IO uint32_t MMCTIR;
+  __IO uint32_t MMCRIMR;
+  __IO uint32_t MMCTIMR;               /*   69 */
   uint32_t      RESERVED3[14];
-  __IOM uint32_t MMCTGFSCCR;            /*   84 */
-  __IOM uint32_t MMCTGFMSCCR;
+  __IO uint32_t MMCTGFSCCR;            /*   84 */
+  __IO uint32_t MMCTGFMSCCR;
   uint32_t      RESERVED4[5];
-  __IOM uint32_t MMCTGFCR;
+  __IO uint32_t MMCTGFCR;
   uint32_t      RESERVED5[10];
-  __IOM uint32_t MMCRFCECR;
-  __IOM uint32_t MMCRFAECR;
+  __IO uint32_t MMCRFCECR;
+  __IO uint32_t MMCRFAECR;
   uint32_t      RESERVED6[10];
-  __IOM uint32_t MMCRGUFCR;
+  __IO uint32_t MMCRGUFCR;
   uint32_t      RESERVED7[334];
-  __IOM uint32_t PTPTSCR;
-  __IOM uint32_t PTPSSIR;
-  __IOM uint32_t PTPTSHR;
-  __IOM uint32_t PTPTSLR;
-  __IOM uint32_t PTPTSHUR;
-  __IOM uint32_t PTPTSLUR;
-  __IOM uint32_t PTPTSAR;
-  __IOM uint32_t PTPTTHR;
-  __IOM uint32_t PTPTTLR;
-  __IOM uint32_t RESERVED8;
-  __IOM uint32_t PTPTSSR;
+  __IO uint32_t PTPTSCR;
+  __IO uint32_t PTPSSIR;
+  __IO uint32_t PTPTSHR;
+  __IO uint32_t PTPTSLR;
+  __IO uint32_t PTPTSHUR;
+  __IO uint32_t PTPTSLUR;
+  __IO uint32_t PTPTSAR;
+  __IO uint32_t PTPTTHR;
+  __IO uint32_t PTPTTLR;
+  __IO uint32_t RESERVED8;
+  __IO uint32_t PTPTSSR;
   uint32_t      RESERVED9[565];
-  __IOM uint32_t DMABMR;
-  __IOM uint32_t DMATPDR;
-  __IOM uint32_t DMARPDR;
-  __IOM uint32_t DMARDLAR;
-  __IOM uint32_t DMATDLAR;
-  __IOM uint32_t DMASR;
-  __IOM uint32_t DMAOMR;
-  __IOM uint32_t DMAIER;
-  __IOM uint32_t DMAMFBOCR;
-  __IOM uint32_t DMARSWTR;
+  __IO uint32_t DMABMR;
+  __IO uint32_t DMATPDR;
+  __IO uint32_t DMARPDR;
+  __IO uint32_t DMARDLAR;
+  __IO uint32_t DMATDLAR;
+  __IO uint32_t DMASR;
+  __IO uint32_t DMAOMR;
+  __IO uint32_t DMAIER;
+  __IO uint32_t DMAMFBOCR;
+  __IO uint32_t DMARSWTR;
   uint32_t      RESERVED10[8];
-  __IOM uint32_t DMACHTDR;
-  __IOM uint32_t DMACHRDR;
-  __IOM uint32_t DMACHTBAR;
-  __IOM uint32_t DMACHRBAR;
+  __IO uint32_t DMACHTDR;
+  __IO uint32_t DMACHRDR;
+  __IO uint32_t DMACHTBAR;
+  __IO uint32_t DMACHRBAR;
 } ETH_TypeDef;
 
 /** 
@@ -564,12 +564,12 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
-  __IOM uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
-  __IOM uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
-  __IOM uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
-  __IOM uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
-  __IOM uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
 } EXTI_TypeDef;
 
 /** 
@@ -578,13 +578,13 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
-  __IOM uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
-  __IOM uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
-  __IOM uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
-  __IOM uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
-  __IOM uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
-  __IOM uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
+  __IO uint32_t ACR;      /*!< FLASH access control register,   Address offset: 0x00 */
+  __IO uint32_t KEYR;     /*!< FLASH key register,              Address offset: 0x04 */
+  __IO uint32_t OPTKEYR;  /*!< FLASH option key register,       Address offset: 0x08 */
+  __IO uint32_t SR;       /*!< FLASH status register,           Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< FLASH control register,          Address offset: 0x10 */
+  __IO uint32_t OPTCR;    /*!< FLASH option control register ,  Address offset: 0x14 */
+  __IO uint32_t OPTCR1;   /*!< FLASH option control register 1, Address offset: 0x18 */
 } FLASH_TypeDef;
 
 /** 
@@ -593,7 +593,7 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
+  __IO uint32_t BTCR[8];    /*!< NOR/PSRAM chip-select control register(BCR) and chip-select timing register(BTR), Address offset: 0x00-1C */
 } FMC_Bank1_TypeDef; 
 
 /** 
@@ -602,7 +602,7 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
+  __IO uint32_t BWTR[7];    /*!< NOR/PSRAM write timing registers, Address offset: 0x104-0x11C */
 } FMC_Bank1E_TypeDef;
 
 /** 
@@ -611,12 +611,12 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t PCR;       /*!< NAND Flash control register,                       Address offset: 0x80 */
-  __IOM uint32_t SR;        /*!< NAND Flash FIFO status and interrupt register,     Address offset: 0x84 */
-  __IOM uint32_t PMEM;      /*!< NAND Flash Common memory space timing register,    Address offset: 0x88 */
-  __IOM uint32_t PATT;      /*!< NAND Flash Attribute memory space timing register, Address offset: 0x8C */
+  __IO uint32_t PCR;       /*!< NAND Flash control register,                       Address offset: 0x80 */
+  __IO uint32_t SR;        /*!< NAND Flash FIFO status and interrupt register,     Address offset: 0x84 */
+  __IO uint32_t PMEM;      /*!< NAND Flash Common memory space timing register,    Address offset: 0x88 */
+  __IO uint32_t PATT;      /*!< NAND Flash Attribute memory space timing register, Address offset: 0x8C */
   uint32_t      RESERVED;  /*!< Reserved, 0x90                                                          */
-  __IOM uint32_t ECCR;      /*!< NAND Flash ECC result registers,                   Address offset: 0x94 */
+  __IO uint32_t ECCR;      /*!< NAND Flash ECC result registers,                   Address offset: 0x94 */
 } FMC_Bank3_TypeDef;
 
 /** 
@@ -625,11 +625,11 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
-  __IOM uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
-  __IOM uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
-  __IOM uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
-  __IOM uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
+  __IO uint32_t SDCR[2];        /*!< SDRAM Control registers ,      Address offset: 0x140-0x144  */
+  __IO uint32_t SDTR[2];        /*!< SDRAM Timing registers ,       Address offset: 0x148-0x14C  */
+  __IO uint32_t SDCMR;          /*!< SDRAM Command Mode register,   Address offset: 0x150        */
+  __IO uint32_t SDRTR;          /*!< SDRAM Refresh Timer register,  Address offset: 0x154        */
+  __IO uint32_t SDSR;           /*!< SDRAM Status register,         Address offset: 0x158        */
 } FMC_Bank5_6_TypeDef;
 
 /** 
@@ -638,15 +638,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
-  __IOM uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
-  __IOM uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
-  __IOM uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
-  __IOM uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
-  __IOM uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
-  __IOM uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
-  __IOM uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
-  __IOM uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t MODER;    /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;   /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;  /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;    /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;      /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;      /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;     /*!< GPIO port bit set/reset register,      Address offset: 0x18      */
+  __IO uint32_t LCKR;     /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];   /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
 } GPIO_TypeDef;
 
 /** 
@@ -655,11 +655,11 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
-  __IOM uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
-  __IOM uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
+  __IO uint32_t MEMRMP;       /*!< SYSCFG memory remap register,                      Address offset: 0x00      */
+  __IO uint32_t PMC;          /*!< SYSCFG peripheral mode configuration register,     Address offset: 0x04      */
+  __IO uint32_t EXTICR[4];    /*!< SYSCFG external interrupt configuration registers, Address offset: 0x08-0x14 */
   uint32_t      RESERVED[2];  /*!< Reserved, 0x18-0x1C                                                          */
-  __IOM uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
+  __IO uint32_t CMPCR;        /*!< SYSCFG Compensation cell control register,         Address offset: 0x20      */
 } SYSCFG_TypeDef;
 
 /** 
@@ -668,16 +668,16 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
-  __IOM uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
-  __IOM uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
-  __IOM uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
-  __IOM uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
-  __IOM uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
-  __IOM uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
-  __IOM uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
-  __IOM uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
+  __IO uint32_t CR1;        /*!< I2C Control register 1,     Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< I2C Control register 2,     Address offset: 0x04 */
+  __IO uint32_t OAR1;       /*!< I2C Own address register 1, Address offset: 0x08 */
+  __IO uint32_t OAR2;       /*!< I2C Own address register 2, Address offset: 0x0C */
+  __IO uint32_t DR;         /*!< I2C Data register,          Address offset: 0x10 */
+  __IO uint32_t SR1;        /*!< I2C Status register 1,      Address offset: 0x14 */
+  __IO uint32_t SR2;        /*!< I2C Status register 2,      Address offset: 0x18 */
+  __IO uint32_t CCR;        /*!< I2C Clock control register, Address offset: 0x1C */
+  __IO uint32_t TRISE;      /*!< I2C TRISE register,         Address offset: 0x20 */
+  __IO uint32_t FLTR;       /*!< I2C FLTR register,          Address offset: 0x24 */
 } I2C_TypeDef;
 
 /** 
@@ -686,10 +686,10 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
-  __IOM uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
-  __IOM uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
-  __IOM uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
 } IWDG_TypeDef;
 
 /** 
@@ -699,22 +699,22 @@ typedef struct
 typedef struct
 {
   uint32_t      RESERVED0[2];  /*!< Reserved, 0x00-0x04                                                       */
-  __IOM uint32_t SSCR;          /*!< LTDC Synchronization Size Configuration Register,    Address offset: 0x08 */
-  __IOM uint32_t BPCR;          /*!< LTDC Back Porch Configuration Register,              Address offset: 0x0C */
-  __IOM uint32_t AWCR;          /*!< LTDC Active Width Configuration Register,            Address offset: 0x10 */
-  __IOM uint32_t TWCR;          /*!< LTDC Total Width Configuration Register,             Address offset: 0x14 */
-  __IOM uint32_t GCR;           /*!< LTDC Global Control Register,                        Address offset: 0x18 */
+  __IO uint32_t SSCR;          /*!< LTDC Synchronization Size Configuration Register,    Address offset: 0x08 */
+  __IO uint32_t BPCR;          /*!< LTDC Back Porch Configuration Register,              Address offset: 0x0C */
+  __IO uint32_t AWCR;          /*!< LTDC Active Width Configuration Register,            Address offset: 0x10 */
+  __IO uint32_t TWCR;          /*!< LTDC Total Width Configuration Register,             Address offset: 0x14 */
+  __IO uint32_t GCR;           /*!< LTDC Global Control Register,                        Address offset: 0x18 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x1C-0x20                                                       */
-  __IOM uint32_t SRCR;          /*!< LTDC Shadow Reload Configuration Register,           Address offset: 0x24 */
+  __IO uint32_t SRCR;          /*!< LTDC Shadow Reload Configuration Register,           Address offset: 0x24 */
   uint32_t      RESERVED2[1];  /*!< Reserved, 0x28                                                            */
-  __IOM uint32_t BCCR;          /*!< LTDC Background Color Configuration Register,        Address offset: 0x2C */
+  __IO uint32_t BCCR;          /*!< LTDC Background Color Configuration Register,        Address offset: 0x2C */
   uint32_t      RESERVED3[1];  /*!< Reserved, 0x30                                                            */
-  __IOM uint32_t IER;           /*!< LTDC Interrupt Enable Register,                      Address offset: 0x34 */
-  __IOM uint32_t ISR;           /*!< LTDC Interrupt Status Register,                      Address offset: 0x38 */
-  __IOM uint32_t ICR;           /*!< LTDC Interrupt Clear Register,                       Address offset: 0x3C */
-  __IOM uint32_t LIPCR;         /*!< LTDC Line Interrupt Position Configuration Register, Address offset: 0x40 */
-  __IOM uint32_t CPSR;          /*!< LTDC Current Position Status Register,               Address offset: 0x44 */
-  __IOM uint32_t CDSR;          /*!< LTDC Current Display Status Register,                Address offset: 0x48 */
+  __IO uint32_t IER;           /*!< LTDC Interrupt Enable Register,                      Address offset: 0x34 */
+  __IO uint32_t ISR;           /*!< LTDC Interrupt Status Register,                      Address offset: 0x38 */
+  __IO uint32_t ICR;           /*!< LTDC Interrupt Clear Register,                       Address offset: 0x3C */
+  __IO uint32_t LIPCR;         /*!< LTDC Line Interrupt Position Configuration Register, Address offset: 0x40 */
+  __IO uint32_t CPSR;          /*!< LTDC Current Position Status Register,               Address offset: 0x44 */
+  __IO uint32_t CDSR;          /*!< LTDC Current Display Status Register,                Address offset: 0x48 */
 } LTDC_TypeDef;
 
 /** 
@@ -723,20 +723,20 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< LTDC Layerx Control Register                                  Address offset: 0x84 */
-  __IOM uint32_t WHPCR;         /*!< LTDC Layerx Window Horizontal Position Configuration Register Address offset: 0x88 */
-  __IOM uint32_t WVPCR;         /*!< LTDC Layerx Window Vertical Position Configuration Register   Address offset: 0x8C */
-  __IOM uint32_t CKCR;          /*!< LTDC Layerx Color Keying Configuration Register               Address offset: 0x90 */
-  __IOM uint32_t PFCR;          /*!< LTDC Layerx Pixel Format Configuration Register               Address offset: 0x94 */
-  __IOM uint32_t CACR;          /*!< LTDC Layerx Constant Alpha Configuration Register             Address offset: 0x98 */
-  __IOM uint32_t DCCR;          /*!< LTDC Layerx Default Color Configuration Register              Address offset: 0x9C */
-  __IOM uint32_t BFCR;          /*!< LTDC Layerx Blending Factors Configuration Register           Address offset: 0xA0 */
+  __IO uint32_t CR;            /*!< LTDC Layerx Control Register                                  Address offset: 0x84 */
+  __IO uint32_t WHPCR;         /*!< LTDC Layerx Window Horizontal Position Configuration Register Address offset: 0x88 */
+  __IO uint32_t WVPCR;         /*!< LTDC Layerx Window Vertical Position Configuration Register   Address offset: 0x8C */
+  __IO uint32_t CKCR;          /*!< LTDC Layerx Color Keying Configuration Register               Address offset: 0x90 */
+  __IO uint32_t PFCR;          /*!< LTDC Layerx Pixel Format Configuration Register               Address offset: 0x94 */
+  __IO uint32_t CACR;          /*!< LTDC Layerx Constant Alpha Configuration Register             Address offset: 0x98 */
+  __IO uint32_t DCCR;          /*!< LTDC Layerx Default Color Configuration Register              Address offset: 0x9C */
+  __IO uint32_t BFCR;          /*!< LTDC Layerx Blending Factors Configuration Register           Address offset: 0xA0 */
   uint32_t      RESERVED0[2];  /*!< Reserved                                                                           */
-  __IOM uint32_t CFBAR;         /*!< LTDC Layerx Color Frame Buffer Address Register               Address offset: 0xAC */
-  __IOM uint32_t CFBLR;         /*!< LTDC Layerx Color Frame Buffer Length Register                Address offset: 0xB0 */
-  __IOM uint32_t CFBLNR;        /*!< LTDC Layerx ColorFrame Buffer Line Number Register            Address offset: 0xB4 */
+  __IO uint32_t CFBAR;         /*!< LTDC Layerx Color Frame Buffer Address Register               Address offset: 0xAC */
+  __IO uint32_t CFBLR;         /*!< LTDC Layerx Color Frame Buffer Length Register                Address offset: 0xB0 */
+  __IO uint32_t CFBLNR;        /*!< LTDC Layerx ColorFrame Buffer Line Number Register            Address offset: 0xB4 */
   uint32_t      RESERVED1[3];  /*!< Reserved                                                                           */
-  __IOM uint32_t CLUTWR;        /*!< LTDC Layerx CLUT Write Register                               Address offset: 0x144*/
+  __IO uint32_t CLUTWR;        /*!< LTDC Layerx CLUT Write Register                               Address offset: 0x144*/
 } LTDC_Layer_TypeDef;
 
 /** 
@@ -745,8 +745,8 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
-  __IOM uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
 } PWR_TypeDef;
 
 /** 
@@ -755,38 +755,38 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
-  __IOM uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
-  __IOM uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
-  __IOM uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
-  __IOM uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
-  __IOM uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
-  __IOM uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
+  __IO uint32_t CR;            /*!< RCC clock control register,                                  Address offset: 0x00 */
+  __IO uint32_t PLLCFGR;       /*!< RCC PLL configuration register,                              Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC clock configuration register,                            Address offset: 0x08 */
+  __IO uint32_t CIR;           /*!< RCC clock interrupt register,                                Address offset: 0x0C */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                          Address offset: 0x10 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                          Address offset: 0x14 */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 peripheral reset register,                          Address offset: 0x18 */
   uint32_t      RESERVED0;     /*!< Reserved, 0x1C                                                                    */
-  __IOM uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
-  __IOM uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                          Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                          Address offset: 0x24 */
   uint32_t      RESERVED1[2];  /*!< Reserved, 0x28-0x2C                                                               */
-  __IOM uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
-  __IOM uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
-  __IOM uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clock register,                          Address offset: 0x30 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clock register,                          Address offset: 0x34 */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 peripheral clock register,                          Address offset: 0x38 */
   uint32_t      RESERVED2;     /*!< Reserved, 0x3C                                                                    */
-  __IOM uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
-  __IOM uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral clock enable register,                   Address offset: 0x40 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clock enable register,                   Address offset: 0x44 */
   uint32_t      RESERVED3[2];  /*!< Reserved, 0x48-0x4C                                                               */
-  __IOM uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
-  __IOM uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
-  __IOM uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
+  __IO uint32_t AHB1LPENR;     /*!< RCC AHB1 peripheral clock enable in low power mode register, Address offset: 0x50 */
+  __IO uint32_t AHB2LPENR;     /*!< RCC AHB2 peripheral clock enable in low power mode register, Address offset: 0x54 */
+  __IO uint32_t AHB3LPENR;     /*!< RCC AHB3 peripheral clock enable in low power mode register, Address offset: 0x58 */
   uint32_t      RESERVED4;     /*!< Reserved, 0x5C                                                                    */
-  __IOM uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
-  __IOM uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
+  __IO uint32_t APB1LPENR;     /*!< RCC APB1 peripheral clock enable in low power mode register, Address offset: 0x60 */
+  __IO uint32_t APB2LPENR;     /*!< RCC APB2 peripheral clock enable in low power mode register, Address offset: 0x64 */
   uint32_t      RESERVED5[2];  /*!< Reserved, 0x68-0x6C                                                               */
-  __IOM uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
-  __IOM uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
+  __IO uint32_t BDCR;          /*!< RCC Backup domain control register,                          Address offset: 0x70 */
+  __IO uint32_t CSR;           /*!< RCC clock control & status register,                         Address offset: 0x74 */
   uint32_t      RESERVED6[2];  /*!< Reserved, 0x78-0x7C                                                               */
-  __IOM uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
-  __IOM uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
-  __IOM uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
-  __IOM uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
+  __IO uint32_t SSCGR;         /*!< RCC spread spectrum clock generation register,               Address offset: 0x80 */
+  __IO uint32_t PLLI2SCFGR;    /*!< RCC PLLI2S configuration register,                           Address offset: 0x84 */
+  __IO uint32_t PLLSAICFGR;    /*!< RCC PLLSAI configuration register,                           Address offset: 0x88 */
+  __IO uint32_t DCKCFGR;       /*!< RCC Dedicated Clocks configuration register,                 Address offset: 0x8C */
 } RCC_TypeDef;
 
 /** 
@@ -795,46 +795,46 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
-  __IOM uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
-  __IOM uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
-  __IOM uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
-  __IOM uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
-  __IOM uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
-  __IOM uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
-  __IOM uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
-  __IOM uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
-  __IOM uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
-  __IOM uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
-  __IOM uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
-  __IOM uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
-  __IOM uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
-  __IOM uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
-  __IOM uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
-  __IOM uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
-  __IOM uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
-  __IOM uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
+  __IO uint32_t TR;      /*!< RTC time register,                                        Address offset: 0x00 */
+  __IO uint32_t DR;      /*!< RTC date register,                                        Address offset: 0x04 */
+  __IO uint32_t CR;      /*!< RTC control register,                                     Address offset: 0x08 */
+  __IO uint32_t ISR;     /*!< RTC initialization and status register,                   Address offset: 0x0C */
+  __IO uint32_t PRER;    /*!< RTC prescaler register,                                   Address offset: 0x10 */
+  __IO uint32_t WUTR;    /*!< RTC wakeup timer register,                                Address offset: 0x14 */
+  __IO uint32_t CALIBR;  /*!< RTC calibration register,                                 Address offset: 0x18 */
+  __IO uint32_t ALRMAR;  /*!< RTC alarm A register,                                     Address offset: 0x1C */
+  __IO uint32_t ALRMBR;  /*!< RTC alarm B register,                                     Address offset: 0x20 */
+  __IO uint32_t WPR;     /*!< RTC write protection register,                            Address offset: 0x24 */
+  __IO uint32_t SSR;     /*!< RTC sub second register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;  /*!< RTC shift control register,                               Address offset: 0x2C */
+  __IO uint32_t TSTR;    /*!< RTC time stamp time register,                             Address offset: 0x30 */
+  __IO uint32_t TSDR;    /*!< RTC time stamp date register,                             Address offset: 0x34 */
+  __IO uint32_t TSSSR;   /*!< RTC time-stamp sub second register,                       Address offset: 0x38 */
+  __IO uint32_t CALR;    /*!< RTC calibration register,                                 Address offset: 0x3C */
+  __IO uint32_t TAFCR;   /*!< RTC tamper and alternate function configuration register, Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;/*!< RTC alarm A sub second register,                          Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;/*!< RTC alarm B sub second register,                          Address offset: 0x48 */
   uint32_t RESERVED7;    /*!< Reserved, 0x4C                                                                 */
-  __IOM uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
-  __IOM uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
-  __IOM uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
-  __IOM uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
-  __IOM uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
-  __IOM uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
-  __IOM uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
-  __IOM uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
-  __IOM uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
-  __IOM uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
-  __IOM uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
-  __IOM uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
-  __IOM uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
-  __IOM uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
-  __IOM uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
-  __IOM uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
-  __IOM uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
-  __IOM uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
-  __IOM uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
-  __IOM uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
+  __IO uint32_t BKP0R;   /*!< RTC backup register 1,                                    Address offset: 0x50 */
+  __IO uint32_t BKP1R;   /*!< RTC backup register 1,                                    Address offset: 0x54 */
+  __IO uint32_t BKP2R;   /*!< RTC backup register 2,                                    Address offset: 0x58 */
+  __IO uint32_t BKP3R;   /*!< RTC backup register 3,                                    Address offset: 0x5C */
+  __IO uint32_t BKP4R;   /*!< RTC backup register 4,                                    Address offset: 0x60 */
+  __IO uint32_t BKP5R;   /*!< RTC backup register 5,                                    Address offset: 0x64 */
+  __IO uint32_t BKP6R;   /*!< RTC backup register 6,                                    Address offset: 0x68 */
+  __IO uint32_t BKP7R;   /*!< RTC backup register 7,                                    Address offset: 0x6C */
+  __IO uint32_t BKP8R;   /*!< RTC backup register 8,                                    Address offset: 0x70 */
+  __IO uint32_t BKP9R;   /*!< RTC backup register 9,                                    Address offset: 0x74 */
+  __IO uint32_t BKP10R;  /*!< RTC backup register 10,                                   Address offset: 0x78 */
+  __IO uint32_t BKP11R;  /*!< RTC backup register 11,                                   Address offset: 0x7C */
+  __IO uint32_t BKP12R;  /*!< RTC backup register 12,                                   Address offset: 0x80 */
+  __IO uint32_t BKP13R;  /*!< RTC backup register 13,                                   Address offset: 0x84 */
+  __IO uint32_t BKP14R;  /*!< RTC backup register 14,                                   Address offset: 0x88 */
+  __IO uint32_t BKP15R;  /*!< RTC backup register 15,                                   Address offset: 0x8C */
+  __IO uint32_t BKP16R;  /*!< RTC backup register 16,                                   Address offset: 0x90 */
+  __IO uint32_t BKP17R;  /*!< RTC backup register 17,                                   Address offset: 0x94 */
+  __IO uint32_t BKP18R;  /*!< RTC backup register 18,                                   Address offset: 0x98 */
+  __IO uint32_t BKP19R;  /*!< RTC backup register 19,                                   Address offset: 0x9C */
 } RTC_TypeDef;
 
 /** 
@@ -843,19 +843,19 @@ typedef struct
   
 typedef struct
 {
-  __IOM uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
+  __IO uint32_t GCR;      /*!< SAI global configuration register,        Address offset: 0x00 */
 } SAI_TypeDef;
 
 typedef struct
 {
-  __IOM uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
-  __IOM uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
-  __IOM uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
-  __IOM uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
-  __IOM uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
-  __IOM uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
-  __IOM uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
+  __IO uint32_t CR1;      /*!< SAI block x configuration register 1,     Address offset: 0x04 */
+  __IO uint32_t CR2;      /*!< SAI block x configuration register 2,     Address offset: 0x08 */
+  __IO uint32_t FRCR;     /*!< SAI block x frame configuration register, Address offset: 0x0C */
+  __IO uint32_t SLOTR;    /*!< SAI block x slot register,                Address offset: 0x10 */
+  __IO uint32_t IMR;      /*!< SAI block x interrupt mask register,      Address offset: 0x14 */
+  __IO uint32_t SR;       /*!< SAI block x status register,              Address offset: 0x18 */
+  __IO uint32_t CLRFR;    /*!< SAI block x clear flag register,          Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< SAI block x data register,                Address offset: 0x20 */
 } SAI_Block_TypeDef;
 
 /** 
@@ -864,26 +864,26 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
-  __IOM uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
-  __IOM uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
-  __IOM uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
-  __IOM const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
-  __IOM const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
-  __IOM const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
-  __IOM const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
-  __IOM const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
-  __IOM uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
-  __IOM uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
-  __IOM uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
-  __IOM const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
-  __IOM const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
-  __IOM uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
-  __IOM uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
+  __IO uint32_t POWER;                 /*!< SDIO power control register,    Address offset: 0x00 */
+  __IO uint32_t CLKCR;                 /*!< SDI clock control register,     Address offset: 0x04 */
+  __IO uint32_t ARG;                   /*!< SDIO argument register,         Address offset: 0x08 */
+  __IO uint32_t CMD;                   /*!< SDIO command register,          Address offset: 0x0C */
+  __IO const uint32_t  RESPCMD;        /*!< SDIO command response register, Address offset: 0x10 */
+  __IO const uint32_t  RESP1;          /*!< SDIO response 1 register,       Address offset: 0x14 */
+  __IO const uint32_t  RESP2;          /*!< SDIO response 2 register,       Address offset: 0x18 */
+  __IO const uint32_t  RESP3;          /*!< SDIO response 3 register,       Address offset: 0x1C */
+  __IO const uint32_t  RESP4;          /*!< SDIO response 4 register,       Address offset: 0x20 */
+  __IO uint32_t DTIMER;                /*!< SDIO data timer register,       Address offset: 0x24 */
+  __IO uint32_t DLEN;                  /*!< SDIO data length register,      Address offset: 0x28 */
+  __IO uint32_t DCTRL;                 /*!< SDIO data control register,     Address offset: 0x2C */
+  __IO const uint32_t  DCOUNT;         /*!< SDIO data counter register,     Address offset: 0x30 */
+  __IO const uint32_t  STA;            /*!< SDIO status register,           Address offset: 0x34 */
+  __IO uint32_t ICR;                   /*!< SDIO interrupt clear register,  Address offset: 0x38 */
+  __IO uint32_t MASK;                  /*!< SDIO mask register,             Address offset: 0x3C */
   uint32_t      RESERVED0[2];          /*!< Reserved, 0x40-0x44                                  */
-  __IOM const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
+  __IO const uint32_t  FIFOCNT;        /*!< SDIO FIFO counter register,     Address offset: 0x48 */
   uint32_t      RESERVED1[13];         /*!< Reserved, 0x4C-0x7C                                  */
-  __IOM uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
+  __IO uint32_t FIFO;                  /*!< SDIO data FIFO register,        Address offset: 0x80 */
 } SDIO_TypeDef;
 
 /** 
@@ -892,15 +892,15 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
-  __IOM uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
-  __IOM uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
-  __IOM uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
-  __IOM uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
-  __IOM uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
-  __IOM uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
-  __IOM uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
-  __IOM uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
+  __IO uint32_t CR1;        /*!< SPI control register 1 (not used in I2S mode),      Address offset: 0x00 */
+  __IO uint32_t CR2;        /*!< SPI control register 2,                             Address offset: 0x04 */
+  __IO uint32_t SR;         /*!< SPI status register,                                Address offset: 0x08 */
+  __IO uint32_t DR;         /*!< SPI data register,                                  Address offset: 0x0C */
+  __IO uint32_t CRCPR;      /*!< SPI CRC polynomial register (not used in I2S mode), Address offset: 0x10 */
+  __IO uint32_t RXCRCR;     /*!< SPI RX CRC register (not used in I2S mode),         Address offset: 0x14 */
+  __IO uint32_t TXCRCR;     /*!< SPI TX CRC register (not used in I2S mode),         Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;    /*!< SPI_I2S configuration register,                     Address offset: 0x1C */
+  __IO uint32_t I2SPR;      /*!< SPI_I2S prescaler register,                         Address offset: 0x20 */
 } SPI_TypeDef;
 
 /** 
@@ -909,19 +909,19 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
-  __IOM uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
-  __IOM uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
-  __IOM uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
-  __IOM uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
-  __IOM uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
-  __IOM uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
-  __IOM uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
-  __IOM uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
-  __IOM uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
-  __IOM uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
-  __IOM uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
-  __IOM uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
+  __IO uint32_t CR;       /*!< QUADSPI Control register,                           Address offset: 0x00 */
+  __IO uint32_t DCR;      /*!< QUADSPI Device Configuration register,              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< QUADSPI Status register,                            Address offset: 0x08 */
+  __IO uint32_t FCR;      /*!< QUADSPI Flag Clear register,                        Address offset: 0x0C */
+  __IO uint32_t DLR;      /*!< QUADSPI Data Length register,                       Address offset: 0x10 */
+  __IO uint32_t CCR;      /*!< QUADSPI Communication Configuration register,       Address offset: 0x14 */
+  __IO uint32_t AR;       /*!< QUADSPI Address register,                           Address offset: 0x18 */
+  __IO uint32_t ABR;      /*!< QUADSPI Alternate Bytes register,                   Address offset: 0x1C */
+  __IO uint32_t DR;       /*!< QUADSPI Data register,                              Address offset: 0x20 */
+  __IO uint32_t PSMKR;    /*!< QUADSPI Polling Status Mask register,               Address offset: 0x24 */
+  __IO uint32_t PSMAR;    /*!< QUADSPI Polling Status Match register,              Address offset: 0x28 */
+  __IO uint32_t PIR;      /*!< QUADSPI Polling Interval register,                  Address offset: 0x2C */
+  __IO uint32_t LPTR;     /*!< QUADSPI Low Power Timeout register,                 Address offset: 0x30 */
 } QUADSPI_TypeDef;
 
 /** 
@@ -930,27 +930,27 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
-  __IOM uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
-  __IOM uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
-  __IOM uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
-  __IOM uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
-  __IOM uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
-  __IOM uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
-  __IOM uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
-  __IOM uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
-  __IOM uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
-  __IOM uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
-  __IOM uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
-  __IOM uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IOM uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
-  __IOM uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
-  __IOM uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
-  __IOM uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-  __IOM uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
-  __IOM uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
-  __IOM uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
-  __IOM uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
+  __IO uint32_t CR1;         /*!< TIM control register 1,              Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,              Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,     Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,   Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                 Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,       Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1, Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2, Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register, Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register,                 Address offset: 0x50 */
 } TIM_TypeDef;
 
 /** 
@@ -959,13 +959,13 @@ typedef struct
  
 typedef struct
 {
-  __IOM uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
-  __IOM uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
-  __IOM uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
-  __IOM uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
-  __IOM uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
-  __IOM uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
-  __IOM uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
+  __IO uint32_t SR;         /*!< USART Status register,                   Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< USART Data register,                     Address offset: 0x04 */
+  __IO uint32_t BRR;        /*!< USART Baud rate register,                Address offset: 0x08 */
+  __IO uint32_t CR1;        /*!< USART Control register 1,                Address offset: 0x0C */
+  __IO uint32_t CR2;        /*!< USART Control register 2,                Address offset: 0x10 */
+  __IO uint32_t CR3;        /*!< USART Control register 3,                Address offset: 0x14 */
+  __IO uint32_t GTPR;       /*!< USART Guard time and prescaler register, Address offset: 0x18 */
 } USART_TypeDef;
 
 /** 
@@ -974,9 +974,9 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
-  __IOM uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
-  __IOM uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
 } WWDG_TypeDef;
 
 /** 
@@ -985,42 +985,42 @@ typedef struct
 
 typedef struct
 {
-  __IOM uint32_t CR;         /*!< CRYP control register,                                    Address offset: 0x00 */
-  __IOM uint32_t SR;         /*!< CRYP status register,                                     Address offset: 0x04 */
-  __IOM uint32_t DIN;         /*!< CRYP data input register,                                 Address offset: 0x08 */
-  __IOM uint32_t DOUT;       /*!< CRYP data output register,                                Address offset: 0x0C */
-  __IOM uint32_t DMACR;      /*!< CRYP DMA control register,                                Address offset: 0x10 */
-  __IOM uint32_t IMSCR;      /*!< CRYP interrupt mask set/clear register,                   Address offset: 0x14 */
-  __IOM uint32_t RISR;       /*!< CRYP raw interrupt status register,                       Address offset: 0x18 */
-  __IOM uint32_t MISR;       /*!< CRYP masked interrupt status register,                    Address offset: 0x1C */
-  __IOM uint32_t K0LR;       /*!< CRYP key left  register 0,                                Address offset: 0x20 */
-  __IOM uint32_t K0RR;       /*!< CRYP key right register 0,                                Address offset: 0x24 */
-  __IOM uint32_t K1LR;       /*!< CRYP key left  register 1,                                Address offset: 0x28 */
-  __IOM uint32_t K1RR;       /*!< CRYP key right register 1,                                Address offset: 0x2C */
-  __IOM uint32_t K2LR;       /*!< CRYP key left  register 2,                                Address offset: 0x30 */
-  __IOM uint32_t K2RR;       /*!< CRYP key right register 2,                                Address offset: 0x34 */
-  __IOM uint32_t K3LR;       /*!< CRYP key left  register 3,                                Address offset: 0x38 */
-  __IOM uint32_t K3RR;       /*!< CRYP key right register 3,                                Address offset: 0x3C */
-  __IOM uint32_t IV0LR;      /*!< CRYP initialization vector left-word  register 0,         Address offset: 0x40 */
-  __IOM uint32_t IV0RR;      /*!< CRYP initialization vector right-word register 0,         Address offset: 0x44 */
-  __IOM uint32_t IV1LR;      /*!< CRYP initialization vector left-word  register 1,         Address offset: 0x48 */
-  __IOM uint32_t IV1RR;      /*!< CRYP initialization vector right-word register 1,         Address offset: 0x4C */
-  __IOM uint32_t CSGCMCCM0R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 0,        Address offset: 0x50 */
-  __IOM uint32_t CSGCMCCM1R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 1,        Address offset: 0x54 */
-  __IOM uint32_t CSGCMCCM2R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 2,        Address offset: 0x58 */
-  __IOM uint32_t CSGCMCCM3R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 3,        Address offset: 0x5C */
-  __IOM uint32_t CSGCMCCM4R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 4,        Address offset: 0x60 */
-  __IOM uint32_t CSGCMCCM5R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 5,        Address offset: 0x64 */
-  __IOM uint32_t CSGCMCCM6R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 6,        Address offset: 0x68 */
-  __IOM uint32_t CSGCMCCM7R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 7,        Address offset: 0x6C */
-  __IOM uint32_t CSGCM0R;    /*!< CRYP GCM/GMAC context swap register 0,                    Address offset: 0x70 */
-  __IOM uint32_t CSGCM1R;    /*!< CRYP GCM/GMAC context swap register 1,                    Address offset: 0x74 */
-  __IOM uint32_t CSGCM2R;    /*!< CRYP GCM/GMAC context swap register 2,                    Address offset: 0x78 */
-  __IOM uint32_t CSGCM3R;    /*!< CRYP GCM/GMAC context swap register 3,                    Address offset: 0x7C */
-  __IOM uint32_t CSGCM4R;    /*!< CRYP GCM/GMAC context swap register 4,                    Address offset: 0x80 */
-  __IOM uint32_t CSGCM5R;    /*!< CRYP GCM/GMAC context swap register 5,                    Address offset: 0x84 */
-  __IOM uint32_t CSGCM6R;    /*!< CRYP GCM/GMAC context swap register 6,                    Address offset: 0x88 */
-  __IOM uint32_t CSGCM7R;    /*!< CRYP GCM/GMAC context swap register 7,                    Address offset: 0x8C */
+  __IO uint32_t CR;         /*!< CRYP control register,                                    Address offset: 0x00 */
+  __IO uint32_t SR;         /*!< CRYP status register,                                     Address offset: 0x04 */
+  __IO uint32_t DIN;         /*!< CRYP data input register,                                 Address offset: 0x08 */
+  __IO uint32_t DOUT;       /*!< CRYP data output register,                                Address offset: 0x0C */
+  __IO uint32_t DMACR;      /*!< CRYP DMA control register,                                Address offset: 0x10 */
+  __IO uint32_t IMSCR;      /*!< CRYP interrupt mask set/clear register,                   Address offset: 0x14 */
+  __IO uint32_t RISR;       /*!< CRYP raw interrupt status register,                       Address offset: 0x18 */
+  __IO uint32_t MISR;       /*!< CRYP masked interrupt status register,                    Address offset: 0x1C */
+  __IO uint32_t K0LR;       /*!< CRYP key left  register 0,                                Address offset: 0x20 */
+  __IO uint32_t K0RR;       /*!< CRYP key right register 0,                                Address offset: 0x24 */
+  __IO uint32_t K1LR;       /*!< CRYP key left  register 1,                                Address offset: 0x28 */
+  __IO uint32_t K1RR;       /*!< CRYP key right register 1,                                Address offset: 0x2C */
+  __IO uint32_t K2LR;       /*!< CRYP key left  register 2,                                Address offset: 0x30 */
+  __IO uint32_t K2RR;       /*!< CRYP key right register 2,                                Address offset: 0x34 */
+  __IO uint32_t K3LR;       /*!< CRYP key left  register 3,                                Address offset: 0x38 */
+  __IO uint32_t K3RR;       /*!< CRYP key right register 3,                                Address offset: 0x3C */
+  __IO uint32_t IV0LR;      /*!< CRYP initialization vector left-word  register 0,         Address offset: 0x40 */
+  __IO uint32_t IV0RR;      /*!< CRYP initialization vector right-word register 0,         Address offset: 0x44 */
+  __IO uint32_t IV1LR;      /*!< CRYP initialization vector left-word  register 1,         Address offset: 0x48 */
+  __IO uint32_t IV1RR;      /*!< CRYP initialization vector right-word register 1,         Address offset: 0x4C */
+  __IO uint32_t CSGCMCCM0R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 0,        Address offset: 0x50 */
+  __IO uint32_t CSGCMCCM1R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 1,        Address offset: 0x54 */
+  __IO uint32_t CSGCMCCM2R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 2,        Address offset: 0x58 */
+  __IO uint32_t CSGCMCCM3R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 3,        Address offset: 0x5C */
+  __IO uint32_t CSGCMCCM4R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 4,        Address offset: 0x60 */
+  __IO uint32_t CSGCMCCM5R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 5,        Address offset: 0x64 */
+  __IO uint32_t CSGCMCCM6R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 6,        Address offset: 0x68 */
+  __IO uint32_t CSGCMCCM7R; /*!< CRYP GCM/GMAC or CCM/CMAC context swap register 7,        Address offset: 0x6C */
+  __IO uint32_t CSGCM0R;    /*!< CRYP GCM/GMAC context swap register 0,                    Address offset: 0x70 */
+  __IO uint32_t CSGCM1R;    /*!< CRYP GCM/GMAC context swap register 1,                    Address offset: 0x74 */
+  __IO uint32_t CSGCM2R;    /*!< CRYP GCM/GMAC context swap register 2,                    Address offset: 0x78 */
+  __IO uint32_t CSGCM3R;    /*!< CRYP GCM/GMAC context swap register 3,                    Address offset: 0x7C */
+  __IO uint32_t CSGCM4R;    /*!< CRYP GCM/GMAC context swap register 4,                    Address offset: 0x80 */
+  __IO uint32_t CSGCM5R;    /*!< CRYP GCM/GMAC context swap register 5,                    Address offset: 0x84 */
+  __IO uint32_t CSGCM6R;    /*!< CRYP GCM/GMAC context swap register 6,                    Address offset: 0x88 */
+  __IO uint32_t CSGCM7R;    /*!< CRYP GCM/GMAC context swap register 7,                    Address offset: 0x8C */
 } CRYP_TypeDef;
 
 /** 
@@ -1029,14 +1029,14 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;               /*!< HASH control register,          Address offset: 0x00        */
-  __IOM uint32_t DIN;              /*!< HASH data input register,       Address offset: 0x04        */
-  __IOM uint32_t STR;              /*!< HASH start register,            Address offset: 0x08        */
-  __IOM uint32_t HR[5];            /*!< HASH digest registers,          Address offset: 0x0C-0x1C   */
-  __IOM uint32_t IMR;              /*!< HASH interrupt enable register, Address offset: 0x20        */
-  __IOM uint32_t SR;               /*!< HASH status register,           Address offset: 0x24        */
+  __IO uint32_t CR;               /*!< HASH control register,          Address offset: 0x00        */
+  __IO uint32_t DIN;              /*!< HASH data input register,       Address offset: 0x04        */
+  __IO uint32_t STR;              /*!< HASH start register,            Address offset: 0x08        */
+  __IO uint32_t HR[5];            /*!< HASH digest registers,          Address offset: 0x0C-0x1C   */
+  __IO uint32_t IMR;              /*!< HASH interrupt enable register, Address offset: 0x20        */
+  __IO uint32_t SR;               /*!< HASH status register,           Address offset: 0x24        */
        uint32_t RESERVED[52];     /*!< Reserved, 0x28-0xF4                                         */
-  __IOM uint32_t CSR[54];          /*!< HASH context swap registers,    Address offset: 0x0F8-0x1CC */
+  __IO uint32_t CSR[54];          /*!< HASH context swap registers,    Address offset: 0x0F8-0x1CC */
 } HASH_TypeDef;
 
 /** 
@@ -1045,7 +1045,7 @@ typedef struct
 
 typedef struct 
 {
-  __IOM uint32_t HR[8];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */ 
+  __IO uint32_t HR[8];     /*!< HASH digest registers,          Address offset: 0x310-0x32C */ 
 } HASH_DIGEST_TypeDef;
 
 /** 
@@ -1054,9 +1054,9 @@ typedef struct
   
 typedef struct 
 {
-  __IOM uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
-  __IOM uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
-  __IOM uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
 } RNG_TypeDef;
 
 /** 
@@ -1064,30 +1064,30 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
-  __IOM uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
-  __IOM uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
-  __IOM uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
-  __IOM uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
-  __IOM uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
-  __IOM uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
-  __IOM uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
-  __IOM uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
-  __IOM uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
-  __IOM uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
-  __IOM uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
+  __IO uint32_t GOTGCTL;              /*!< USB_OTG Control and Status Register          000h */
+  __IO uint32_t GOTGINT;              /*!< USB_OTG Interrupt Register                   004h */
+  __IO uint32_t GAHBCFG;              /*!< Core AHB Configuration Register              008h */
+  __IO uint32_t GUSBCFG;              /*!< Core USB Configuration Register              00Ch */
+  __IO uint32_t GRSTCTL;              /*!< Core Reset Register                          010h */
+  __IO uint32_t GINTSTS;              /*!< Core Interrupt Register                      014h */
+  __IO uint32_t GINTMSK;              /*!< Core Interrupt Mask Register                 018h */
+  __IO uint32_t GRXSTSR;              /*!< Receive Sts Q Read Register                  01Ch */
+  __IO uint32_t GRXSTSP;              /*!< Receive Sts Q Read & POP Register            020h */
+  __IO uint32_t GRXFSIZ;              /*!< Receive FIFO Size Register                   024h */
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /*!< EP0 / Non Periodic Tx FIFO Size Register     028h */
+  __IO uint32_t HNPTXSTS;             /*!< Non Periodic Tx FIFO/Queue Sts reg           02Ch */
   uint32_t Reserved30[2];             /*!< Reserved                                     030h */
-  __IOM uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
-  __IOM uint32_t CID;                  /*!< User ID Register                             03Ch */
+  __IO uint32_t GCCFG;                /*!< General Purpose IO Register                  038h */
+  __IO uint32_t CID;                  /*!< User ID Register                             03Ch */
   uint32_t  Reserved5[3];             /*!< Reserved                                040h-048h */
-  __IOM uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
+  __IO uint32_t GHWCFG3;              /*!< User HW config3                              04Ch */
   uint32_t  Reserved6;                /*!< Reserved                                     050h */
-  __IOM uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
+  __IO uint32_t GLPMCFG;              /*!< LPM Register                                 054h */
   uint32_t  Reserved;                 /*!< Reserved                                     058h */
-  __IOM uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
+  __IO uint32_t GDFIFOCFG;            /*!< DFIFO Software Config Register               05Ch */
   uint32_t  Reserved43[40];           /*!< Reserved                                058h-0FFh */
-  __IOM uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
-  __IOM uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
+  __IO uint32_t HPTXFSIZ;             /*!< Host Periodic Tx FIFO Size Reg               100h */
+  __IO uint32_t DIEPTXF[0x0F];        /*!< dev Periodic Transmit FIFO                        */
 } USB_OTG_GlobalTypeDef;
 
 /** 
@@ -1095,26 +1095,26 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DCFG;            /*!< dev Configuration Register   800h */
-  __IOM uint32_t DCTL;            /*!< dev Control Register         804h */
-  __IOM uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
+  __IO uint32_t DCFG;            /*!< dev Configuration Register   800h */
+  __IO uint32_t DCTL;            /*!< dev Control Register         804h */
+  __IO uint32_t DSTS;            /*!< dev Status Register (RO)     808h */
   uint32_t Reserved0C;           /*!< Reserved                     80Ch */
-  __IOM uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
-  __IOM uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
-  __IOM uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
-  __IOM uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
+  __IO uint32_t DIEPMSK;         /*!< dev IN Endpoint Mask         810h */
+  __IO uint32_t DOEPMSK;         /*!< dev OUT Endpoint Mask        814h */
+  __IO uint32_t DAINT;           /*!< dev All Endpoints Itr Reg    818h */
+  __IO uint32_t DAINTMSK;        /*!< dev All Endpoints Itr Mask   81Ch */
   uint32_t  Reserved20;          /*!< Reserved                     820h */
   uint32_t Reserved9;            /*!< Reserved                     824h */
-  __IOM uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
-  __IOM uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
-  __IOM uint32_t DTHRCTL;         /*!< dev threshold                830h */
-  __IOM uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
-  __IOM uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
-  __IOM uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
+  __IO uint32_t DVBUSDIS;        /*!< dev VBUS discharge Register  828h */
+  __IO uint32_t DVBUSPULSE;      /*!< dev VBUS Pulse Register      82Ch */
+  __IO uint32_t DTHRCTL;         /*!< dev threshold                830h */
+  __IO uint32_t DIEPEMPMSK;      /*!< dev empty msk                834h */
+  __IO uint32_t DEACHINT;        /*!< dedicated EP interrupt       838h */
+  __IO uint32_t DEACHMSK;        /*!< dedicated EP msk             83Ch */
   uint32_t Reserved40;           /*!< dedicated EP mask            840h */
-  __IOM uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
+  __IO uint32_t DINEP1MSK;       /*!< dedicated EP mask            844h */
   uint32_t  Reserved44[15];      /*!< Reserved                 844-87Ch */
-  __IOM uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
+  __IO uint32_t DOUTEP1MSK;      /*!< dedicated EP msk             884h */
 } USB_OTG_DeviceTypeDef;
 
 /** 
@@ -1122,13 +1122,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
+  __IO uint32_t DIEPCTL;           /*!< dev IN Endpoint Control Reg    900h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;             /*!< Reserved                       900h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
+  __IO uint32_t DIEPINT;           /*!< dev IN Endpoint Itr Reg        900h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;             /*!< Reserved                       900h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
-  __IOM uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
+  __IO uint32_t DIEPTSIZ;          /*!< IN Endpoint Txfer Size         900h + (ep_num * 20h) + 10h */
+  __IO uint32_t DIEPDMA;           /*!< IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h */
+  __IO uint32_t DTXFSTS;           /*!< IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h */
   uint32_t Reserved18;             /*!< Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch */
 } USB_OTG_INEndpointTypeDef;
 
@@ -1137,12 +1137,12 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
+  __IO uint32_t DOEPCTL;       /*!< dev OUT Endpoint Control Reg           B00h + (ep_num * 20h) + 00h */
   uint32_t Reserved04;         /*!< Reserved                               B00h + (ep_num * 20h) + 04h */
-  __IOM uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
+  __IO uint32_t DOEPINT;       /*!< dev OUT Endpoint Itr Reg               B00h + (ep_num * 20h) + 08h */
   uint32_t Reserved0C;         /*!< Reserved                               B00h + (ep_num * 20h) + 0Ch */
-  __IOM uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
-  __IOM uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
+  __IO uint32_t DOEPTSIZ;      /*!< dev OUT Endpoint Txfer Size            B00h + (ep_num * 20h) + 10h */
+  __IO uint32_t DOEPDMA;       /*!< dev OUT Endpoint DMA Address           B00h + (ep_num * 20h) + 14h */
   uint32_t Reserved18[2];      /*!< Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch */
 } USB_OTG_OUTEndpointTypeDef;
 
@@ -1151,13 +1151,13 @@ typedef struct
   */
 typedef struct 
 {
-  __IOM uint32_t HCFG;             /*!< Host Configuration Register          400h */
-  __IOM uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
-  __IOM uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
+  __IO uint32_t HCFG;             /*!< Host Configuration Register          400h */
+  __IO uint32_t HFIR;             /*!< Host Frame Interval Register         404h */
+  __IO uint32_t HFNUM;            /*!< Host Frame Nbr/Frame Remaining       408h */
   uint32_t Reserved40C;           /*!< Reserved                             40Ch */
-  __IOM uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
-  __IOM uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
-  __IOM uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
+  __IO uint32_t HPTXSTS;          /*!< Host Periodic Tx FIFO/ Queue Status  410h */
+  __IO uint32_t HAINT;            /*!< Host All Channels Interrupt Register 414h */
+  __IO uint32_t HAINTMSK;         /*!< Host All Channels Interrupt Mask     418h */
 } USB_OTG_HostTypeDef;
 
 /** 
@@ -1165,12 +1165,12 @@ typedef struct
   */
 typedef struct
 {
-  __IOM uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
-  __IOM uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
-  __IOM uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
-  __IOM uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
-  __IOM uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
-  __IOM uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
+  __IO uint32_t HCCHAR;           /*!< Host Channel Characteristics Register    500h */
+  __IO uint32_t HCSPLT;           /*!< Host Channel Split Control Register      504h */
+  __IO uint32_t HCINT;            /*!< Host Channel Interrupt Register          508h */
+  __IO uint32_t HCINTMSK;         /*!< Host Channel Interrupt Mask Register     50Ch */
+  __IO uint32_t HCTSIZ;           /*!< Host Channel Transfer Size Register      510h */
+  __IO uint32_t HCDMA;            /*!< Host Channel DMA Address Register        514h */
   uint32_t Reserved[2];           /*!< Reserved                                      */
 } USB_OTG_HostChannelTypeDef;
 


### PR DESCRIPTION
Reverts utkarshsethi/cmsis_device_f4#1